### PR TITLE
chore: `formatAsPhp` utility

### DIFF
--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -48,7 +48,7 @@ export class DirectiveNode implements Node {
     }
 
     toString(): string {
-        return `@${this.directive}${this.code ? `(${this.code})` : ''}`
+        return `@${this.directive}${this.code ? `(${formatAsPhp(this.code)})` : ''}`
     }
 }
 

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -1,7 +1,6 @@
 import { doc, format } from 'prettier'
-// @ts-ignore
-import php from '@prettier/plugin-php/standalone'
 import {builders} from "prettier/doc";
+import { formatAsPhp } from '../../utils';
 import Doc = builders.Doc;
 
 const { builders: { group, softline, indent } } = doc
@@ -35,11 +34,9 @@ export class EchoNode implements Node {
     }
 
     toString(): string {
-        let code = format(`<?php ${this.code}`, { parser: 'php', plugins: [php] }).replace('<?php ', '').trim()
-        code = code.substring(0, code.length - 1)
-
         const [open, close] = EchoType.toStringParts(this.type)
-        return `${open} ${code} ${close}`
+
+        return `${open} ${formatAsPhp(this.code)} ${close}`
     }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+import { format } from 'prettier'
+// @ts-ignore
+import php from '@prettier/plugin-php/standalone'
+
+export const formatAsPhp = (source: string): string => {
+    if (! source.startsWith('<?php')) {
+        source = '<?php ' + source;
+    }
+
+    let code = format(source, { parser: 'php', plugins: [php] }).replace('<?php ', '').trim()
+
+    if (source.trim().endsWith(';')) {
+        return code
+    }
+
+    // The PHP plugin for Prettier will add a semi-colon by default. We don't want always want that.
+    return code.substring(0, code.length - 1)
+}


### PR DESCRIPTION
Adds a new `formatAsPhp` utility function that handles the `<?php` non-sense.