### PR TITLE
feature: add support for escaped echos

### DIFF
--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -30,11 +30,11 @@ export class Lexer {
                 break
             }
 
-            if (this.current === '{' && this.next === '{') {
+            if (this.previous !== '@' && this.current === '{' && this.next === '{') {
                 this.tokens.push(this.echo())
             } if (this.current === '{' && this.next === '!' && this.source[this.i + 2] === '!') {
                 this.tokens.push(this.rawEcho())
-            } else if (this.current === '@' && this.next !== '@') {
+            } else if (this.current === '@' && ! ['@', '{'].includes(this.next)) {
                 this.tokens.push(this.directive())
             } else {
                 this.buffer += this.current

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -32,7 +32,7 @@ export class Lexer {
 
             if (this.previous !== '@' && this.current === '{' && this.next === '{') {
                 this.tokens.push(this.echo())
-            } if (this.current === '{' && this.next === '!' && this.source[this.i + 2] === '!') {
+            } if (this.previous !== '@' && this.current === '{' && this.next === '!' && this.source[this.i + 2] === '!') {
                 this.tokens.push(this.rawEcho())
             } else if (this.current === '@' && ! ['@', '{'].includes(this.next)) {
                 this.tokens.push(this.directive())

--- a/tests/escaped-echo/__snapshots__/escaped-echo.test.ts.snap
+++ b/tests/escaped-echo/__snapshots__/escaped-echo.test.ts.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`basic 1`] = `
+"Escaped echos should be left @{{asTheyAre}}
+"
+`;

--- a/tests/escaped-echo/__snapshots__/escaped-echo.test.ts.snap
+++ b/tests/escaped-echo/__snapshots__/escaped-echo.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic 1`] = `
-"Escaped echos should be left @{{asTheyAre}}
+"Escaped echos should be left @{{asTheyAre}} like @{!!this!!}
 "
 `;

--- a/tests/escaped-echo/escaped-echo.blade.php
+++ b/tests/escaped-echo/escaped-echo.blade.php
@@ -1,1 +1,1 @@
-Escaped echos should be left @{{asTheyAre}}
+Escaped echos should be left @{{asTheyAre}} like @{!!this!!}

--- a/tests/escaped-echo/escaped-echo.blade.php
+++ b/tests/escaped-echo/escaped-echo.blade.php
@@ -1,0 +1,1 @@
+Escaped echos should be left @{{asTheyAre}}

--- a/tests/escaped-echo/escaped-echo.test.ts
+++ b/tests/escaped-echo/escaped-echo.test.ts
@@ -1,0 +1,10 @@
+import fs from "fs";
+import path from "path";
+import { format } from "../utils";
+
+const fixture = fs.readFileSync(path.join(__dirname, "./escaped-echo.blade.php"), "utf-8");
+
+test("basic", () => {
+    const formatted = format(fixture);
+    expect(formatted).toMatchSnapshot();
+});


### PR DESCRIPTION
Will parse `@{{ }}` and `@{!! !!}` literally without formatting.