### PR TITLE
fix(lexer): Fix lookahead, not actually checking the next by default

### DIFF
--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -198,7 +198,7 @@ export class Lexer {
   }
 
   lookahead(amount: number = 1) {
-    return this.collect(amount, 1);
+    return this.collect(amount + 1, 1);
   }
 
   lookbehind(amount: number = 1) {


### PR DESCRIPTION
Looks like I forgot to add a +1 to the lookahead method, so by default it would get the same index.