### PR TITLE
refactor: use enums

### DIFF
--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -188,7 +188,7 @@ export class Lexer {
             }
 
             // @ts-ignore
-            if (this.current === ')') {
+            if (this.current === ")") {
                 parens -= 1;
             }
 

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -76,7 +76,7 @@ export class Lexer {
             this.read();
         }
 
-        return new Token(TokenType.T_ECHO, raw, this.line);
+        return new Token(TokenType.Echo, raw, this.line);
     }
 
     rawEcho(): Token {
@@ -102,7 +102,7 @@ export class Lexer {
             this.read();
         }
 
-        return new Token(TokenType.T_RAW_ECHO, raw, this.line);
+        return new Token(TokenType.RawEcho, raw, this.line);
     }
 
     comment(): Token {
@@ -128,7 +128,7 @@ export class Lexer {
             this.read();
         }
 
-        return new Token(TokenType.T_COMMENT, raw, this.line);
+        return new Token(TokenType.Comment, raw, this.line);
     }
 
     directive(): Token {
@@ -147,7 +147,7 @@ export class Lexer {
         }
 
         if (this.stackPointer >= this.source.length) {
-            return new Token(TokenType.T_DIRECTIVE, match.trim(), this.line);
+            return new Token(TokenType.Directive, match.trim(), this.line);
         }
 
         const DIRECTIVE_ORIGINAL_LINE = this.line;
@@ -161,7 +161,7 @@ export class Lexer {
             this.buffer += whitespace + this.current;
 
             return new Token(
-                TokenType.T_DIRECTIVE,
+                TokenType.Directive,
                 match.trim(),
                 DIRECTIVE_ORIGINAL_LINE
             );
@@ -195,13 +195,13 @@ export class Lexer {
             this.read();
         }
 
-        return new Token(TokenType.T_DIRECTIVE, match.trim(), this.line);
+        return new Token(TokenType.Directive, match.trim(), this.line);
     }
 
     literal() {
         if (this.buffer.length > 0) {
             this.tokens.push(
-                new Token(TokenType.T_LITERAL, this.buffer, this.line)
+                new Token(TokenType.Literal, this.buffer, this.line)
             );
             this.buffer = "";
         }

--- a/src/lang/parser.ts
+++ b/src/lang/parser.ts
@@ -73,7 +73,7 @@ export class Parser {
         this.read();
         this.read();
 
-        while (this.current.type !== TokenType.T_EOF) {
+        while (this.current.type !== TokenType.Eof) {
             this.nodes.push(this.node());
         }
 
@@ -81,13 +81,13 @@ export class Parser {
     }
 
     node(): Node {
-        if (this.current.type === TokenType.T_ECHO) {
+        if (this.current.type === TokenType.Echo) {
             return this.echo();
-        } else if (this.current.type === TokenType.T_RAW_ECHO) {
+        } else if (this.current.type === TokenType.RawEcho) {
             return this.rawEcho();
-        } else if (this.current.type === TokenType.T_DIRECTIVE) {
+        } else if (this.current.type === TokenType.Directive) {
             return this.directive();
-        } else if (this.current.type === TokenType.T_COMMENT) {
+        } else if (this.current.type === TokenType.Comment) {
             return this.comment();
         } else {
             const node = new Nodes.LiteralNode(this.current.raw);
@@ -166,7 +166,7 @@ export class Parser {
         let children = [];
         let close = null;
 
-        while (this.current.type !== TokenType.T_EOF) {
+        while (this.current.type !== TokenType.Eof) {
             const child = this.node();
 
             if (

--- a/src/lang/token.ts
+++ b/src/lang/token.ts
@@ -8,7 +8,11 @@ export enum TokenType {
 }
 
 export class Token {
-    constructor(public type: TokenType, public raw: string, public line: number) {}
+    constructor(
+        public type: TokenType,
+        public raw: string,
+        public line: number
+    ) {}
 
     static eof() {
         return new Token(TokenType.Eof, "", 0);

--- a/src/lang/token.ts
+++ b/src/lang/token.ts
@@ -1,16 +1,16 @@
-export const TokenType = {
-    T_DIRECTIVE: "directive",
-    T_ECHO: "echo",
-    T_RAW_ECHO: "raw_echo",
-    T_LITERAL: "literal",
-    T_EOF: "eof",
-    T_COMMENT: "comment",
-};
+export enum TokenType {
+    Directive,
+    Echo,
+    RawEcho,
+    Literal,
+    Eof,
+    Comment,
+}
 
 export class Token {
-    constructor(public type: string, public raw: string, public line: number) {}
+    constructor(public type: TokenType, public raw: string, public line: number) {}
 
     static eof() {
-        return new Token(TokenType.T_EOF, "", 0);
+        return new Token(TokenType.Eof, "", 0);
     }
 }

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -30,9 +30,9 @@ it("can generate raw echo tokens", () => {
 });
 
 it("can generate directive tokens", () => {
-    const tokens = lex("@php @if(true) @else() @if  (true) @if(auth()) @if(')' === '@test')").filter(
-        (token) => token.type !== TokenType.Literal && !!token.raw.trim()
-    );
+    const tokens = lex(
+        "@php @if(true) @else() @if  (true) @if(auth()) @if(')' === '@test')"
+    ).filter((token) => token.type !== TokenType.Literal && !!token.raw.trim());
 
     expect(tokens[0]).toHaveProperty("type", TokenType.Directive);
     expect(tokens[0]).toHaveProperty("raw", "@php");
@@ -46,7 +46,7 @@ it("can generate directive tokens", () => {
     expect(tokens[3]).toHaveProperty("type", TokenType.Directive);
     expect(tokens[3]).toHaveProperty("raw", "@if  (true)");
 
-    expect(tokens[4]).toHaveProperty("type", TokenType.Directive)
+    expect(tokens[4]).toHaveProperty("type", TokenType.Directive);
     expect(tokens[4]).toHaveProperty("raw", "@if(auth())");
 });
 

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -8,56 +8,56 @@ const lex = (source: string): Token[] => {
 it("can generate echo tokens", () => {
     const echo = lex("{{ $test }}")[0];
 
-    expect(echo).toHaveProperty("type", TokenType.T_ECHO);
+    expect(echo).toHaveProperty("type", TokenType.Echo);
     expect(echo).toHaveProperty("raw", "{{ $test }}");
 
     const spaceless = lex("{{$test}}")[0];
 
-    expect(spaceless).toHaveProperty("type", TokenType.T_ECHO);
+    expect(spaceless).toHaveProperty("type", TokenType.Echo);
     expect(spaceless).toHaveProperty("raw", "{{$test}}");
 });
 
 it("can generate raw echo tokens", () => {
     const raw = lex("{!! $test !!}")[0];
 
-    expect(raw).toHaveProperty("type", TokenType.T_RAW_ECHO);
+    expect(raw).toHaveProperty("type", TokenType.RawEcho);
     expect(raw).toHaveProperty("raw", "{!! $test !!}");
 
     const spaceless = lex("{!!$test!!}")[0];
 
-    expect(spaceless).toHaveProperty("type", TokenType.T_RAW_ECHO);
+    expect(spaceless).toHaveProperty("type", TokenType.RawEcho);
     expect(spaceless).toHaveProperty("raw", "{!!$test!!}");
 });
 
 it("can generate directive tokens", () => {
     const tokens = lex("@php @if(true) @else() @if  (true) @if(auth()) @if(')' === '@test')").filter(
-        (token) => token.type !== TokenType.T_LITERAL && !!token.raw.trim()
+        (token) => token.type !== TokenType.Literal && !!token.raw.trim()
     );
 
-    expect(tokens[0]).toHaveProperty("type", TokenType.T_DIRECTIVE);
+    expect(tokens[0]).toHaveProperty("type", TokenType.Directive);
     expect(tokens[0]).toHaveProperty("raw", "@php");
 
-    expect(tokens[1]).toHaveProperty("type", TokenType.T_DIRECTIVE);
+    expect(tokens[1]).toHaveProperty("type", TokenType.Directive);
     expect(tokens[1]).toHaveProperty("raw", "@if(true)");
 
-    expect(tokens[2]).toHaveProperty("type", TokenType.T_DIRECTIVE);
+    expect(tokens[2]).toHaveProperty("type", TokenType.Directive);
     expect(tokens[2]).toHaveProperty("raw", "@else()");
 
-    expect(tokens[3]).toHaveProperty("type", TokenType.T_DIRECTIVE);
+    expect(tokens[3]).toHaveProperty("type", TokenType.Directive);
     expect(tokens[3]).toHaveProperty("raw", "@if  (true)");
 
-    expect(tokens[4]).toHaveProperty("type", TokenType.T_DIRECTIVE)
+    expect(tokens[4]).toHaveProperty("type", TokenType.Directive)
     expect(tokens[4]).toHaveProperty("raw", "@if(auth())");
 });
 
 it("can generate comment tokens", () => {
     const raw = lex("{{-- $test --}}")[0];
 
-    expect(raw).toHaveProperty("type", TokenType.T_COMMENT);
+    expect(raw).toHaveProperty("type", TokenType.Comment);
     expect(raw).toHaveProperty("raw", "{{-- $test --}}");
 
     const spaceless = lex("{{--$test--}}")[0];
 
-    expect(spaceless).toHaveProperty("type", TokenType.T_COMMENT);
+    expect(spaceless).toHaveProperty("type", TokenType.Comment);
     expect(spaceless).toHaveProperty("raw", "{{--$test--}}");
 });


### PR DESCRIPTION
Migrates the old `const TokenType` object literal to an enum.