### PR TITLE
fix(directive): Fix pair directive newlines and indents

### DIFF
--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -153,6 +153,10 @@ export class Lexer {
         const DIRECTIVE_ORIGINAL_LINE = this.line;
 
         while (ctype_space(this.current)) {
+            if (this.stackPointer >= this.source.length) {
+                return new Token(TokenType.Directive, match.trim(), this.line);
+            }
+
             whitespace += this.current;
             this.read();
         }
@@ -220,7 +224,7 @@ export class Lexer {
     }
 
     lookbehind(amount: number = 1) {
-        return this.collect(-amount, amount);
+        return this.collect(0, -amount);
     }
 
     get current() {

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -4,7 +4,7 @@ import { formatAsPhp } from "../../utils";
 import Doc = builders.Doc;
 
 const {
-    builders: { group, softline, indent },
+    builders: { group, softline, indent, line, hardline },
 } = doc;
 
 export interface Node {
@@ -73,7 +73,7 @@ export class LiteralNode implements Node {
     }
 
     toString(): string {
-        return this.content;
+        return this.content.trimStart();
     }
 }
 
@@ -86,9 +86,10 @@ export class DirectivePairNode implements Node {
 
     toDoc(): Doc {
         return group([
-            softline,
             this.open.toDoc(),
-            this.children.map((child) => indent(child.toDoc())),
+            hardline,
+            this.children.map((child) => child.toDoc()),
+            hardline,
             this.close.toDoc(),
         ]);
     }

--- a/src/lang/parser.ts
+++ b/src/lang/parser.ts
@@ -140,8 +140,9 @@ export class Parser {
                 directiveName.indexOf("(")
             );
         }
+        directiveName = directiveName.trim();
 
-        let inner = this.current.raw.replace("@" + directiveName, "");
+        let inner = this.current.raw.replace("@" + directiveName, "").trim();
         if (inner.startsWith("(")) {
             inner = inner.substring(1);
         }

--- a/tests/__fixtures__/comment/escaped.blade.php
+++ b/tests/__fixtures__/comment/escaped.blade.php
@@ -1,4 +1,4 @@
     <h1>
     Here's some very nice text @{{--This is actually not that nice--}}</h1>
 ----
-<h1>Here's some very nice text @{{--This is actually not that nice--}}</h1>
+<h1>Here's some very nice text @{{-- This is actually not that nice --}}</h1>

--- a/tests/__fixtures__/directive/auth-directive.blade.php
+++ b/tests/__fixtures__/directive/auth-directive.blade.php
@@ -1,0 +1,6 @@
+@auth("admin")
+The user is authenticated...@endauth
+----
+@auth("admin")
+The user is authenticated...
+@endauth

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -1,5 +1,6 @@
 import { Lexer } from "../src/lang/lexer";
 import { Token, TokenType } from "../src/lang/token";
+import exp from "constants";
 
 const lex = (source: string): Token[] => {
     return new Lexer(source).all();
@@ -60,4 +61,13 @@ it("can generate comment tokens", () => {
 
     expect(spaceless).toHaveProperty("type", TokenType.Comment);
     expect(spaceless).toHaveProperty("raw", "{{--$test--}}");
+});
+
+it("should parse directive if ended with space", function () {
+    const tokens = lex("@csrf ");
+
+    expect(tokens).toHaveLength(1);
+
+    expect(tokens[0]).toHaveProperty("type", TokenType.Directive);
+    expect(tokens[0]).toHaveProperty("raw", "@csrf");
 });


### PR DESCRIPTION
Fixes a test for pair directives and also fixes a bug with lookbehind