### PR TITLE
Bug/fix echo replacement

### DIFF
--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -14,7 +14,7 @@ export class Lexer {
     private buffer: string = "";
     constructor(source: string) {
         this.source = source
-            .replace(/<\?=\s+(\".+\")\s+\?\>/, "{{!! $1 !!}}")
+            .replace(/<\?=\s+(\".+\")\s+\?\>/, "{!! $1 !!}")
             .replace(/(\<\?(php)?\n)(.+)(\n\s+\?\>)/gm, "@php$3 @endphp")
             .replace(/\r\n|\r|\n/, "\n")
             .split("");
@@ -32,9 +32,7 @@ export class Lexer {
                 this.tokens.push(this.comment());
             } else if (this.previous !== "@" && this.collect(2) === "{{") {
                 this.tokens.push(this.echo());
-            }
-
-            if (this.previous !== "@" && this.collect(3) === "{!!") {
+            } else if (this.previous !== "@" && this.collect(3) === "{!!") {
                 this.tokens.push(this.rawEcho());
             } else if (
                 this.previous !== "@" &&

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -14,6 +14,7 @@ export class Lexer {
     private buffer: string = "";
     constructor(source: string) {
         this.source = source
+            .replace(/<\?=\s+(\".+\")\s+\?\>/, "{{!! $1 !!}}")
             .replace(/(\<\?(php)?\n)(.+)(\n\s+\?\>)/gm, "@php$3 @endphp")
             .replace(/\r\n|\r|\n/, "\n")
             .split("");

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -14,8 +14,7 @@ export class Lexer {
     private buffer: string = "";
     constructor(source: string) {
         this.source = source
-            .replace("<?php", "@php")
-            .replace("?>", "@endphp")
+            .replace(/(\<\?(php)?\n)(.+)(\n\s+\?\>)/gm, "@php$3 @endphp")
             .replace(/\r\n|\r|\n/, "\n")
             .split("");
     }

--- a/tests/__fixtures__/php-tags/php-echo-tags.blade.php
+++ b/tests/__fixtures__/php-tags/php-echo-tags.blade.php
@@ -2,5 +2,5 @@
 <h1>Awesome
 </h1>
 ----
-{{!! "Cool stuff" !!}}
+{!! "Cool stuff" !!}
 <h1>Awesome</h1>

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -85,3 +85,17 @@ it("should parse multiple no args directives", function () {
     expect(tokens[2]).toHaveProperty("type", TokenType.Directive);
     expect(tokens[2]).toHaveProperty("raw", "@csrf");
 });
+
+it("can generate raw echo tokens when wrapped in parenthesis", () => {
+    const raw = lex("{{!! 'yes' !!}}")[0];
+
+    expect(raw).toHaveProperty("type", TokenType.RawEcho);
+    expect(raw).toHaveProperty("raw", "{!! 'yes' !!}");
+});
+
+it("can generate echo token when starting with double negation", () => {
+    const raw = lex("{{!!$value}}")[0];
+
+    expect(raw).toHaveProperty("type", TokenType.Echo);
+    expect(raw).toHaveProperty("raw", "{{!!$value}}");
+});


### PR DESCRIPTION
This works based in the browser:

```'<?= "Cool stuff" ?>'.replace(/<\?=\s+(\".+\")\s+\?\>/, "{{!! $1 !!}}")```

In the tests, its still not working, as the existing code is forcing an extra space between the `{{` and the `!!`