### PR TITLE
feature(cli): initial version

### DIFF
--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const argparse_1 = require("argparse");
+const fs_1 = require("fs");
+const utils_1 = require("../tests/utils");
+const parser = new argparse_1.ArgumentParser({
+    description: 'A small command-line tool to test the Blade plugin on fixture files.',
+    add_help: true,
+});
+parser.add_argument('file', { help: 'The file to format.' });
+const args = parser.parse_args();
+const [original, _] = (0, fs_1.readFileSync)(args.file, 'utf-8')
+    .split("----")
+    .map((part) => part.trimStart());
+process.stdout.write((0, utils_1.format)(original));

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "@ryangjchandler/prettier-plugin-blade",
     "main": "dist/src",
     "devDependencies": {
+        "@types/argparse": "^2.0.10",
         "@types/jest": "^27.0.0",
         "@types/node": "^17.0.4",
         "jest": "^27.0.1",
@@ -16,6 +17,7 @@
     },
     "dependencies": {
         "@prettier/plugin-php": "^0.17.6",
+        "argparse": "^2.0.1",
         "prettier": "^2.5.1",
         "prettier-plugin-tailwindcss": "^0.1.4"
     },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,17 @@
+import { ArgumentParser } from 'argparse'
+import { readFileSync } from 'fs'
+import { format } from '../tests/utils'
+
+const parser = new ArgumentParser({
+    description: 'A small command-line tool to test the Blade plugin on fixture files.',
+    add_help: true,
+})
+
+parser.add_argument('file', { help: 'The file to format.' })
+
+const args = parser.parse_args()
+const [original, _] = readFileSync(args.file, 'utf-8')
+    .split("----")
+    .map((part) => part.trimStart());
+
+process.stdout.write(format(original))


### PR DESCRIPTION
Adds a small CLI tool that can be used to format fixture files - should make testing a little easier instead of doing #27.

You will need to build the TS first, so run `tsc --build` in the root of the project. Then you can run `node ./dist/src/cli.js --help` to see the help message.

Provide the path to a fixture file and it will output the formatted version in the console.