### PR TITLE
Add new component slot syntax

### DIFF
--- a/tests/__fixtures__/components/component-namespace-tag.blade.php
+++ b/tests/__fixtures__/components/component-namespace-tag.blade.php
@@ -1,6 +1,12 @@
 <x-view x="X" :y="'Y'">
 <x-slot name="Name">
             <div>Named Slot</div></x-slot>
+
+<x-slot:trigger>
+                <div>Trigger Slot</div>
+    </x-slot:trigger><x-slot:footer>
+<div>Footer Slot</div>
+</x-slot>
 <div>
         Default Slot</div>
         </x-view>
@@ -8,6 +14,14 @@
 <x-namespace::view x="X" :y="'Y'">
     <x-slot name="Name">
         <div>Named Slot</div>
+    </x-slot>
+
+    <x-slot:trigger>
+        <div>Trigger Slot</div>
+    </x-slot:trigger>
+
+    <x-slot:footer>
+        <div>Footer Slot</div>
     </x-slot>
     
     <div>Default Slot</div>

--- a/tests/__fixtures__/components/component-tag.blade.php
+++ b/tests/__fixtures__/components/component-tag.blade.php
@@ -1,6 +1,12 @@
 <x-view x="X" :y="'Y'">
 <x-slot name="Name">
             <div>Named Slot</div></x-slot>
+
+<x-slot:trigger>
+                <div>Trigger Slot</div>
+    </x-slot:trigger><x-slot:footer>
+<div>Footer Slot</div>
+</x-slot>
 <div>
         Default Slot</div>
         </x-view>
@@ -8,6 +14,14 @@
 <x-view x="X" :y="'Y'">
     <x-slot name="Name">
         <div>Named Slot</div>
+    </x-slot>
+
+    <x-slot:trigger>
+        <div>Trigger Slot</div>
+    </x-slot:trigger>
+
+    <x-slot:footer>
+        <div>Footer Slot</div>
     </x-slot>
     
     <div>Default Slot</div>


### PR DESCRIPTION
https://laravel.com/docs/9.x/blade#slot-attributes

The new Syntax allows more options on how to define which slot the content is for.

In my opinion the formatter should change how the slot name is defined to one default. 
What I would prefer is the following:
```blade
{{-- Before Formatting --}}
<x-view x="X" :y="'Y'">
    <x-slot name="Name">
        <div>Named Slot</div>
    </x-slot>

    <x-slot:trigger>
        <div>Trigger Slot</div>
    </x-slot:trigger>

    <x-slot:footer>
        <div>Footer Slot</div>
    </x-slot>
    
    <div>Default Slot</div>
</x-view>

{{-- After Formatting --}}
<x-view x="X" :y="'Y'">
    <x-slot:Name>
        <div>Named Slot</div>
    </x-slot:Name>

    <x-slot:trigger>
        <div>Trigger Slot</div>
    </x-slot:trigger>

    <x-slot:footer>
        <div>Footer Slot</div>
    </x-slot:footer>
    
    <div>Default Slot</div>
</x-view>
```

I will send another PR which implements my personal style. So that you can decide which one you want to accept.