### PR TITLE
Various test fixes, `@php` directive support

### DIFF
--- a/src/lang/blade_cst.d.ts
+++ b/src/lang/blade_cst.d.ts
@@ -25,6 +25,7 @@ export type ContentCstChildren = {
     escapedEcho?: EscapedEchoCstNode[];
     escapedRawEcho?: EscapedRawEchoCstNode[];
     verbatimBlockDirective?: VerbatimBlockDirectiveCstNode[];
+    phpBlockDirective?: PhpBlockDirectiveCstNode[];
 };
 
 export interface DirectiveCstNode extends CstNode {
@@ -215,6 +216,35 @@ export type VerbatimBlockDirectiveCstChildren = {
     startDirective: StartVerbatimDirectiveCstNode[];
     content?: ContentCstNode[];
     endDirective: EndVerbatimDirectiveCstNode[];
+};
+
+export interface StartPhpDirectiveCstNode extends CstNode {
+    name: "startPhpDirective";
+    children: StartPhpDirectiveCstChildren;
+}
+
+export type StartPhpDirectiveCstChildren = {
+    StartPhpDirective: IToken[];
+};
+
+export interface EndPhpDirectiveCstNode extends CstNode {
+    name: "endPhpDirective";
+    children: EndPhpDirectiveCstChildren;
+}
+
+export type EndPhpDirectiveCstChildren = {
+    EndPhpDirective: IToken[];
+};
+
+export interface PhpBlockDirectiveCstNode extends CstNode {
+    name: "verbatimBlockDirective";
+    children: PhpBlockDirectiveCstChildren;
+}
+
+export type PhpBlockDirectiveCstChildren = {
+    startDirective: StartPhpDirectiveCstNode[];
+    content?: ContentCstNode[];
+    endDirective: EndPhpDirectiveCstNode[];
 };
 
 export interface ICstNodeVisitor<IN, OUT> extends ICstVisitor<IN, OUT> {

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -17,6 +17,8 @@ export enum Token {
     EndIfDirective = "EndIfDirective",
     StartVerbatimDirective = "StartVerbatimDirective",
     EndVerbatimDirective = "EndVerbatimDirective",
+    StartPhpDirective = "StartPhpDirective",
+    EndPhpDirective = "EndPhpDirective",
 }
 
 enum Mode {
@@ -381,6 +383,56 @@ export const EndVerbatimDirectiveWithArgs = createToken({
     line_breaks: false,
 });
 
+export const StartPhpDirective = createToken({
+    name: Token.StartPhpDirective,
+    pattern: {
+        exec(
+            text: string,
+            startOffset: number
+        ): CustomPatternMatcherReturn | null {
+            const result = matchDirective(text, startOffset);
+
+            if (result === null) {
+                return null;
+            }
+
+            // Check if `@php` directive
+            if (result.directiveName !== "php") {
+                return null;
+            }
+
+            return [result.matches];
+        },
+    },
+    start_chars_hint: ["@"],
+    line_breaks: false,
+});
+
+export const EndPhpDirective = createToken({
+    name: Token.EndPhpDirective,
+    pattern: {
+        exec(
+            text: string,
+            startOffset: number
+        ): CustomPatternMatcherReturn | null {
+            const result = matchDirective(text, startOffset);
+
+            if (result === null) {
+                return null;
+            }
+
+            // Check if `@endphp` directive
+            if (result.directiveName !== "endphp") {
+                return null;
+            }
+
+            return [result.matches];
+        },
+    },
+    start_chars_hint: ["@"],
+    line_breaks: false,
+});
+
 export const Literal = createToken({
     name: Token.Literal,
     pattern: /(.|\n)/,
@@ -394,6 +446,8 @@ export const allTokens = {
             Echo,
             StartVerbatimDirectiveWithArgs,
             EndVerbatimDirectiveWithArgs,
+            StartPhpDirective,
+            EndPhpDirective,
             StartIfDirectiveWithArgs,
             ElseIfDirectiveWithArgs,
             ElseDirectiveWithArgs,

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -133,7 +133,7 @@ function matchDirective(text: string, startOffset: number) {
 
 export const Echo = createToken({
     name: Token.Echo,
-    pattern: /{{\s*(.+?)\s*[^!]}}(\r?\n)?/,
+    pattern: /{{\s*(.+?)\s*}}(\r?\n)?/,
     start_chars_hint: ["{"],
 });
 

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -1,10 +1,4 @@
-import {
-    formatAsHtml,
-    formatAsPhp,
-    nextId,
-    placeholderElement,
-} from "../../utils";
-import { randomUUID } from "crypto";
+import { formatAsPhp, nextId, placeholderElement } from "../../utils";
 
 export type AsHtml = string | HtmlOutput | AsHtml[]
 
@@ -90,7 +84,7 @@ export class DirectiveNode implements Node {
 
     toHtml(): HtmlOutput {
         return {
-            asHtml: `<directive-${this.directive}-${randomUUID()} />`,
+            asHtml: `<directive-${this.directive}-${nextId()} />`,
             asReplacer: this.toString(),
         };
     }
@@ -191,7 +185,7 @@ export class PhpNode implements Node {
 
     toHtml(): HtmlOutput {
         return {
-            asHtml: `<php-${randomUUID()} />`,
+            asHtml: `<php-${nextId()} />`,
             asReplacer: this.toString(),
         };
     }
@@ -263,22 +257,22 @@ export class DirectiveElseBlockNode implements Node {
     ) {}
 
     toHtml(): HtmlOutput {
-        const uuid = nextId();
+        const id = nextId();
 
         return {
             asHtml: [
-                ` <else-${uuid}>`,
+                ` <else-${id}>`,
                 forceHtmlSplit,
                 ...this.children.map((child) => child.toHtml()),
-                ` </else-${uuid}>`,
+                ` </else-${id}>`,
             ],
             asReplacer: [
                 {
-                    search: `<else-${uuid}>`,
+                    search: `<else-${id}>`,
                     replace: this.elseDirective.toString(),
                 },
                 {
-                    search: new RegExp(`\n?.*<\\/else-${uuid}>`),
+                    search: new RegExp(`\n?.*<\\/else-${id}>`),
                     replace: "",
                 },
             ]
@@ -293,22 +287,22 @@ export class DirectiveElseIfBlockNode implements Node {
     ) {}
 
     toHtml(): HtmlOutput {
-        const uuid = nextId();
+        const id = nextId();
 
         return {
             asHtml: [
-                ` <else-if-${uuid}>`,
+                ` <else-if-${id}>`,
                 forceHtmlSplit,
                 ...this.children.map((child) => child.toHtml()),
-                ` </else-if-${uuid}>`,
+                ` </else-if-${id}>`,
             ],
             asReplacer: [
                 {
-                    search: `<else-if-${uuid}>`,
+                    search: `<else-if-${id}>`,
                     replace: this.elseIfDirective.toString(),
                 },
                 {
-                    search: `\n</else-if-${uuid}>`,
+                    search: `\n</else-if-${id}>`,
                     replace: "",
                 },
             ]

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -1,5 +1,10 @@
-import {formatAsHtml, formatAsPhp} from "../../utils";
-import {randomUUID} from "crypto";
+import {
+    formatAsHtml,
+    formatAsPhp,
+    nextId,
+    placeholderElement,
+} from "../../utils";
+import { randomUUID } from "crypto";
 
 export type AsHtml = string | HtmlOutput | AsHtml[]
 
@@ -11,17 +16,11 @@ export interface HtmlOutput {
 export type AsReplacer = Replacer | string | Replacer[]
 
 export interface Replacer {
-    search: string|RegExp
+    search: string | RegExp
     replace: string
 }
 
 const forceHtmlSplit = " <div x-delete-x></div> ";
-
-let id = 1;
-
-const nextId = () => {
-  return ++id;
-}
 
 export interface Node {
     toHtml(): HtmlOutput;
@@ -62,7 +61,7 @@ export class EchoNode implements Node {
 
     toHtml(): HtmlOutput {
         return {
-            asHtml: `<echo-${randomUUID()} />`,
+            asHtml: placeholderElement("e", this.toString()),
             asReplacer: this.toString(),
         };
     }
@@ -192,9 +191,9 @@ export class CommentNode implements Node {
 
     toHtml(): HtmlOutput {
         return {
-            asHtml: `<comment-${randomUUID()} />`,
+            asHtml: placeholderElement("c", this.toString()),
             asReplacer: this.toString(),
-        }
+        };
     }
 }
 

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -182,6 +182,25 @@ export class VerbatimNode implements Node {
     }
 }
 
+export class PhpNode implements Node {
+    constructor(
+        public open: DirectiveNode,
+        public close: DirectiveNode,
+        public code: string
+    ) {}
+
+    toHtml(): HtmlOutput {
+        return {
+            asHtml: `<php-${randomUUID()} />`,
+            asReplacer: this.toString(),
+        };
+    }
+
+    toString(): string {
+        return `@php\n\n${formatAsPhp(this.code)}\n\n@endphp`;
+    }
+}
+
 export class CommentNode implements Node {
     constructor(private code: string, private content: string) {}
 

--- a/src/lang/parser.ts
+++ b/src/lang/parser.ts
@@ -10,6 +10,8 @@ import {
     EscapedRawEcho,
     Literal,
     RawEcho, StartDirectiveWithArgs, StartIfDirectiveWithArgs, StartVerbatimDirectiveWithArgs,
+    StartPhpDirective,
+    EndPhpDirective,
 } from "./lexer";
 
 class BladeToCSTParser extends CstParser {
@@ -55,6 +57,9 @@ class BladeToCSTParser extends CstParser {
             },
             {
                 ALT: () => this.SUBRULE(this.verbatimBlockDirective),
+            },
+            {
+                ALT: () => this.SUBRULE(this.phpBlockDirective),
             },
         ]);
     });
@@ -180,6 +185,24 @@ class BladeToCSTParser extends CstParser {
             });
         });
         this.SUBRULE2(this.endVerbatimDirective, { LABEL: "endDirective" });
+    });
+
+    private startPhpDirective = this.RULE("startPhpDirective", () => {
+        this.CONSUME(StartPhpDirective);
+    });
+
+    private endPhpDirective = this.RULE("endPhpDirective", () => {
+        this.CONSUME(EndPhpDirective);
+    });
+
+    private phpBlockDirective = this.RULE("phpBlockDirective", () => {
+        this.SUBRULE(this.startPhpDirective, { LABEL: "startDirective" });
+        this.OPTION(() => {
+            this.MANY(() => {
+                this.SUBRULE(this.content);
+            });
+        });
+        this.SUBRULE2(this.endPhpDirective, { LABEL: "endDirective" });
     });
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,27 +3,43 @@ import { format, ParserOptions } from "prettier";
 import php from "@prettier/plugin-php/standalone";
 const tw = require("prettier-plugin-tailwindcss");
 
+const debug = false;
+
 let pluginOptions: ParserOptions;
 export const setOptions = (options: ParserOptions) => {
     pluginOptions = options;
 };
 
 export const formatAsHtml = (source: string): string => {
+    let formatted = "";
+    let debugOutput = [""];
+
+    debug && debugOutput.push(`source:    '${source}'`);
+
     try {
-        return format(source, {
+        formatted = format(source, {
             parser: "html",
             plugins: [{ parsers: { html: tw.parsers.html } }],
             tabWidth: pluginOptions?.tabWidth,
-        })
+        });
     } catch (e) {
-        return source
+        debug && debugOutput.push("error: defaulting to source");
+
+        formatted = source;
     }
+
+    debug && debugOutput.push(`formatted: '${formatted}'`);
+    debug && console.log("formatAsHtml", debugOutput.join(`\n`));
+
+    return formatted;
 };
 
 export const formatAsPhp = (source: string): string => {
-    let manipulated = source;
+    let manipulated = (source = source.trim());
+    let formatted = "";
+    let debugOutput = [""];
 
-    if (!source.startsWith("<?php")) {
+    if (!manipulated.startsWith("<?php")) {
         manipulated = "<?php " + manipulated;
     }
 
@@ -31,22 +47,28 @@ export const formatAsPhp = (source: string): string => {
         manipulated += ";";
     }
 
+    debug && debugOutput.push(`source:      '${source}'`);
+    debug && debugOutput.push(`manipulated: '${manipulated}'`);
+
     try {
-        manipulated = format(source, { parser: "php", plugins: [php] })
+        formatted = format(manipulated, { parser: "php", plugins: [php] })
             .replace("<?php ", "")
             .trim();
     } catch (e) {
+        debug && debugOutput.push("error: defaulting to source");
+
         // Fallback to original source if php formatter fails
-        return source.trim();
+        formatted = source;
     }
 
-    if (source.trim().endsWith(";")) {
-        return manipulated;
+    // The PHP plugin for Prettier will add a semi-colon by default. We don't
+    // always want that.
+    if (!source.endsWith(";") && formatted.endsWith(";")) {
+        formatted = formatted.substring(0, formatted.length - 1);
     }
 
-    // The PHP plugin for Prettier will add a semi-colon by default. We don't always want that.
-    if (manipulated.endsWith(";")) {
-        manipulated.substring(0, manipulated.length - 1);
-    }
-    return manipulated;
+    debug && debugOutput.push(`formatted:   '${formatted}'`);
+    debug && console.log("formatAsPhp", debugOutput.join(`\n`));
+
+    return formatted;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,3 +72,25 @@ export const formatAsPhp = (source: string): string => {
 
     return formatted;
 };
+
+let id = 1;
+
+export const nextId = () => {
+    return ++id;
+};
+
+export const placeholderElement = (prefix: string, content: string): string => {
+    let placeholder = `<${prefix}-${nextId()} />`;
+
+    // The placeholder is as short as we can make it. If it's already "too long"
+    // then use it as it b/c there's nothing we can do about it.
+    if (placeholder.length >= content.length) {
+        return placeholder;
+    }
+
+    let lengthToPad = content.length - placeholder.length;
+
+    // Pad the placeholder to be as long as the "content" so it can be wrapped
+    // correctly.
+    return `<${prefix}-${nextId()}-${"x".repeat(lengthToPad - 1)} />`;
+};

--- a/tests/__fixtures__/comment/basic.blade.php
+++ b/tests/__fixtures__/comment/basic.blade.php
@@ -1,6 +1,4 @@
     <h1>
     Here's some very nice text {{--This is actually not that nice--}}</h1>
 ----
-<h1>
-    Here's some very nice text {{-- This is actually not that nice --}}
-</h1>
+<h1>Here's some very nice text {{-- This is actually not that nice --}}</h1>

--- a/tests/__fixtures__/comment/escaped.blade.php
+++ b/tests/__fixtures__/comment/escaped.blade.php
@@ -1,6 +1,4 @@
     <h1>
     Here's some very nice text @{{--This is actually not that nice--}}</h1>
 ----
-<h1>
-    Here's some very nice text @{{-- This is actually not that nice --}}
-</h1>
+<h1>Here's some very nice text @{{-- This is actually not that nice --}}</h1>

--- a/tests/__fixtures__/components/component-directive.blade.php
+++ b/tests/__fixtures__/components/component-directive.blade.php
@@ -7,10 +7,10 @@
     <div>Default Slot</div>
         @endcomponent
 ----
-@component('view')
-    @slot('name', 'value')
-    @slot('name2', true)
-    @slot('name3')
+@component("view")
+    @slot("name", "value")
+    @slot("name2", true)
+    @slot("name3")
         <div>Name3 Slot</div>
     @endslot
 

--- a/tests/__fixtures__/directive/custom-if-directive.blade.php
+++ b/tests/__fixtures__/directive/custom-if-directive.blade.php
@@ -7,14 +7,14 @@ local!
 @unlessdisk('local')something not local@enddisk
 
 ----
-@disk('local')
+@disk("local")
     local!
-@elsedisk('s3')
+@elsedisk("s3")
     s3!
 @else
     not sure?
 @enddisk
 
-@unlessdisk('local')
+@unlessdisk("local")
     something not local
 @enddisk

--- a/tests/__fixtures__/directive/error-directive.blade.php
+++ b/tests/__fixtures__/directive/error-directive.blade.php
@@ -16,8 +16,6 @@
     class="@error('title') is-invalid @enderror"
 />
 
-@error('title')
-    <div class="alert alert-danger">
-        {{ $message }}
-    </div>
+@error("title")
+    <div class="alert alert-danger">{{ $message }}</div>
 @enderror

--- a/tests/__fixtures__/directive/error-directive.blade.php
+++ b/tests/__fixtures__/directive/error-directive.blade.php
@@ -13,7 +13,7 @@
 <input
     id="title"
     type="text"
-    class="@error('title') is-invalid @enderror"
+    class="@error("title") is-invalid @enderror"
 />
 
 @error("title")

--- a/tests/__fixtures__/directive/method-directive.blade.php
+++ b/tests/__fixtures__/directive/method-directive.blade.php
@@ -4,6 +4,6 @@
 </form>
 ----
 <form action="/foo/bar" method="POST">
-    @method('PUT')
+    @method("PUT")
     <input type="text" />
 </form>

--- a/tests/__fixtures__/directive/pair-directive-starting-on-line.blade.php
+++ b/tests/__fixtures__/directive/pair-directive-starting-on-line.blade.php
@@ -2,7 +2,7 @@
 ----
 <h1>
     Welcome!
-    @auth('admin')
+    @auth("admin")
         (you are currently admin)
     @endauth
 </h1>

--- a/tests/__fixtures__/directive/php-directive-short.blade.php
+++ b/tests/__fixtures__/directive/php-directive-short.blade.php
@@ -1,0 +1,7 @@
+@php $this->foo    =   $other->bar(  ) @endphp
+----
+@php
+
+$this->foo = $other->bar()
+
+@endphp

--- a/tests/__fixtures__/directive/php-directive.blade.php
+++ b/tests/__fixtures__/directive/php-directive.blade.php
@@ -1,0 +1,13 @@
+@php
+$this->foo = $other->bar()->baz( )->buzz( 'abc'
+);
+@endphp
+----
+@php
+
+$this->foo = $other
+    ->bar()
+    ->baz()
+    ->buzz("abc");
+
+@endphp

--- a/tests/__fixtures__/directive/prepend-directive.blade.php
+++ b/tests/__fixtures__/directive/prepend-directive.blade.php
@@ -1,5 +1,5 @@
 @prepend('scripts')<script src="/example.js"></script>@endprepend
 ----
-@prepend('scripts')
+@prepend("scripts")
     <script src="/example.js"></script>
 @endprepend

--- a/tests/__fixtures__/directive/push-directive.blade.php
+++ b/tests/__fixtures__/directive/push-directive.blade.php
@@ -1,5 +1,5 @@
 @push('scripts')<script src="/example.js"></script>@endpush
 ----
-@push('scripts')
+@push("scripts")
     <script src="/example.js"></script>
 @endpush

--- a/tests/__fixtures__/directive/stack-directive.blade.php
+++ b/tests/__fixtures__/directive/stack-directive.blade.php
@@ -7,5 +7,5 @@
 <head>
     <!-- Head Contents -->
 
-    @stack('scripts')
+    @stack("scripts")
 </head>

--- a/tests/__fixtures__/directive/yield-directive.blade.php
+++ b/tests/__fixtures__/directive/yield-directive.blade.php
@@ -3,4 +3,4 @@
     'Default content'
 )
 ----
-@yield('content', 'Default content')
+@yield("content", "Default content")

--- a/tests/__fixtures__/echo/multiple-small.blade.php
+++ b/tests/__fixtures__/echo/multiple-small.blade.php
@@ -1,0 +1,17 @@
+<div>This {{$a}} line is short {{$b}}.</div>
+<div>This {{$a}} line is longer {{$b}} but still fits on one line {{$c}}.</div>
+<div>This {{$ab}} line is longer {{$cd}} and doesn't quite fit on one {{$ef}}.</div>
+<div>Here we want to make sure {{$thatThisVariableWrapsBecauseItIsRidiculouslyLong}}.</div>
+----
+<div>This {{ $a }} line is short {{ $b }}.</div>
+<div>
+    This {{ $a }} line is longer {{ $b }} but still fits on one line {{ $c }}.
+</div>
+<div>
+    This {{ $ab }} line is longer {{ $cd }} and doesn't quite fit on one
+    {{ $ef }}.
+</div>
+<div>
+    Here we want to make sure
+    {{ $thatThisVariableWrapsBecauseItIsRidiculouslyLong }}.
+</div>

--- a/tests/__fixtures__/echo/raw.blade.php
+++ b/tests/__fixtures__/echo/raw.blade.php
@@ -1,6 +1,4 @@
     <h1>
     Here's some very poorly formatted {!!$rawEchos!!}</h1>
 ----
-<h1>
-    Here's some very poorly formatted {!! $rawEchos !!}
-</h1>
+<h1>Here's some very poorly formatted {!! $rawEchos !!}</h1>

--- a/tests/__fixtures__/echo/simple.blade.php
+++ b/tests/__fixtures__/echo/simple.blade.php
@@ -2,5 +2,5 @@
     Poorly formatted {{'html'}} with weird {{$echoParts + 1 / $insideOfIt}}</h1>
 ----
 <h1>
-    Poorly formatted {{ 'html' }} with weird {{ $echoParts + 1 / $insideOfIt }}
+    Poorly formatted {{ "html" }} with weird {{ $echoParts + 1 / $insideOfIt }}
 </h1>

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -65,7 +65,7 @@ it("should generate echo token when starting with double negation", () => {
 });
 
 it("should generate raw echo tokens when wrapped in parenthesis", () => {
-    const tokens = lex("{{!! 'yes' !!}}").filter(
+    const tokens = lex("({!! 'yes' !!})").filter(
         (token) => token.tokenType.name !== Token.Literal
     );
 

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -121,7 +121,7 @@ it("should generate directive tokens", () => {
         "@php @something(true) @some() @some  (true) @some(auth()) @some(')' === '@test')"
     ).filter((token) => token.tokenType.name !== Token.Literal);
 
-    expect(tokens[0]).toHaveProperty("tokenType.name", Token.Directive);
+    expect(tokens[0]).toHaveProperty("tokenType.name", Token.StartPhpDirective);
     expect(tokens[0]).toHaveProperty("image", "@php");
 
     expect(tokens[1]).toHaveProperty("tokenType.name", Token.Directive);
@@ -342,3 +342,29 @@ it("should parse endverbatim directive", function () {
 
 
 it.todo("should parse escaped directive as literal");
+
+describe("php directives", () => {
+    it("should parse php directives", function () {
+        const tokens = lex("@php");
+
+        expect(tokens[0]).toHaveProperty(
+            "tokenType.name",
+            Token.StartPhpDirective
+        );
+        expect(tokens[0]).toHaveProperty("image", "@php");
+
+        expect(tokens).toHaveLength(1);
+    });
+
+    it("should parse endphp directives", function () {
+        const tokens = lex("@endphp");
+
+        expect(tokens[0]).toHaveProperty(
+            "tokenType.name",
+            Token.EndPhpDirective
+        );
+        expect(tokens[0]).toHaveProperty("image", "@endphp");
+
+        expect(tokens).toHaveLength(1);
+    });
+});

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -6,6 +6,7 @@ import {
     DirectiveNode,
     DirectivePairNode,
     DocumentNode, LiteralNode, VerbatimNode,
+    PhpNode,
 } from "../src/lang/nodes";
 
 const parse = (source: string): DocumentNode => {
@@ -172,7 +173,17 @@ it("should parse ast verbatim block", function () {
     expect(verbatimBlock.close.directive).toBe("endverbatim");
 });
 
+it("should parse ast php block", function () {
+    const ast = parse("@php $foo = 'bar' @endphp");
 
+    expect(ast.children).toHaveLength(1);
+
+    const phpBlock = ast.children[0] as PhpNode;
+
+    expect(phpBlock.open.directive).toBe("php");
+    expect(phpBlock.code).toEqual(" $foo = 'bar' ");
+    expect(phpBlock.close.directive).toBe("endphp");
+});
 
 it.todo("should parse ast for par directive with child pair directive");
 

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,0 +1,19 @@
+import { placeholderElement } from "../src/utils";
+
+describe("placeholderElement", () => {
+    it("has a minimum length", () => {
+        let content = "{{1}}";
+        let placeHolder = placeholderElement("foo", content);
+
+        expect(content.length).toBeLessThan(placeHolder.length);
+        expect(placeHolder).toMatch(/<foo-\d \/>/);
+    });
+
+    it("pads output to match length of content", () => {
+        let content = "{{ $thisHasLength22 }}";
+        let placeHolder = placeholderElement("foo", content);
+
+        expect(content.length).toBe(placeHolder.length);
+        expect(placeHolder).toMatch(/<foo-\d-x+ \/>/);
+    });
+});


### PR DESCRIPTION
Hi there! This does a few things:

1. tweaks `formatAsPhp` to correct what seemed like some some logic mistakes
In particular, `manipulated` was bring created but was not being used for the formatting, so most php code was not being formatted. This change corrects that. OF the changes included here, this one feels the most solid. I think the original code was just wrong.

2. implements a hack-around for some wrapping issues w/ various directives
This is the code in the 2nd and 3rd commits: 7e5c970 and 9a270da. As you know, the plugin works by replacing Blade code w/ html-ish elements so that they can be formatted as HTML, then it replaces those placeholders w/ the formatted PHP. The issue w/ this is that something like `Hi, my name is {{ $name }}` is being formatted as HTML that looks like `Hi, my name is <echo-really-long-uuid-here />`, and if that `<echo...>` element happens to run over 80 chars (or whatever the line legth is), it will be wrapped. Then, when the PHP is replaced back it, we'll ended up w/ 
```
Hi, my name is
{{ $name }}
```

My "fix" is just a hack that trims these placeholders to match the length of the input code. **This is not a final** solution, but maybe it gets closer? The issue w/ this fix is that if the input code change in length when it's formatted as PHP, then it could mean that we haven't wrapped that line correctly. eg `Pretend this line is only {{79}} chars` will get turned into `Pretend this line is only {{ 79 }} chars`, which is actually 81 chars (b/c of the 2 added spaces around `79`). This feels "better" than the above example, but it's obviously not ideal.

3. Adds support for `@php` directives.
This went OK, I think, but feels very, very boilerplatey. The couple of new tests pass.

This was mostly a learning excercise for me; if these changes aren't desirable (or they're too hacky or just wrong!) it was at least fun to learn my way around the project.
