### PR TITLE
More failing tests

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,8 @@ import { format, ParserOptions } from "prettier";
 import php from "@prettier/plugin-php/standalone";
 const tw = require("prettier-plugin-tailwindcss");
 
-const debug = false;
+const htmlDebug = false;
+const phpDebug = false;
 
 let pluginOptions: ParserOptions;
 export const setOptions = (options: ParserOptions) => {
@@ -14,7 +15,7 @@ export const formatAsHtml = (source: string): string => {
     let formatted = "";
     let debugOutput = [""];
 
-    debug && debugOutput.push(`source:    '${source}'`);
+    htmlDebug && debugOutput.push(`source:    '${source}'`);
 
     try {
         formatted = format(source, {
@@ -23,13 +24,13 @@ export const formatAsHtml = (source: string): string => {
             tabWidth: pluginOptions?.tabWidth,
         });
     } catch (e) {
-        debug && debugOutput.push("error: defaulting to source");
+        htmlDebug && debugOutput.push("error: defaulting to source");
 
         formatted = source;
     }
 
-    debug && debugOutput.push(`formatted: '${formatted}'`);
-    debug && console.log("formatAsHtml", debugOutput.join(`\n`));
+    htmlDebug && debugOutput.push(`formatted: '${formatted}'`);
+    htmlDebug && console.log("formatAsHtml", debugOutput.join(`\n`));
 
     return formatted;
 };
@@ -51,15 +52,15 @@ export const formatAsPhp = (source: string): string => {
         manipulated += ";";
     }
 
-    debug && debugOutput.push(`source:      '${source}'`);
-    debug && debugOutput.push(`manipulated: '${manipulated}'`);
+    phpDebug && debugOutput.push(`source:      '${source}'`);
+    phpDebug && debugOutput.push(`manipulated: '${manipulated}'`);
 
     try {
         formatted = format(manipulated, { parser: "php", plugins: [php] })
             .replace("<?php ", "")
             .trim();
     } catch (e) {
-        debug && debugOutput.push("error: defaulting to source");
+        phpDebug && debugOutput.push("error: defaulting to source");
 
         // Fallback to original source if php formatter fails
         formatted = source;
@@ -71,8 +72,8 @@ export const formatAsPhp = (source: string): string => {
         formatted = formatted.substring(0, formatted.length - 1);
     }
 
-    debug && debugOutput.push(`formatted:   '${formatted}'`);
-    debug && console.log("formatAsPhp", debugOutput.join(`\n`));
+    phpDebug && debugOutput.push(`formatted:   '${formatted}'`);
+    phpDebug && console.log("formatAsPhp", debugOutput.join(`\n`));
 
     return formatted;
 };

--- a/tests/__fixtures__/comment/multiline.blade.php
+++ b/tests/__fixtures__/comment/multiline.blade.php
@@ -1,0 +1,7 @@
+{{--
+  -- This is a multi line comment. It should be preserved as is.
+  --}}
+----
+{{--
+  -- This is a multi line comment. It should be preserved as is.
+  --}}

--- a/tests/__fixtures__/comment/really-long.blade.php
+++ b/tests/__fixtures__/comment/really-long.blade.php
@@ -1,0 +1,3 @@
+{{-- Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. --}}
+----
+{{-- Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. --}}

--- a/tests/__fixtures__/directive/auth-directive.blade.php
+++ b/tests/__fixtures__/directive/auth-directive.blade.php
@@ -1,5 +1,23 @@
 @auth("admin")The user is authenticated...@endauth
+
+@auth The user is authenticated... @endauth
+
+@guest('admin') The user is not authenticated... @endguest
+
+@guest The user is not authenticated... @endguest
 ----
 @auth("admin")
     The user is authenticated...
 @endauth
+
+@auth
+    The user is authenticated...
+@endauth
+
+@guest("admin")
+    The user is not authenticated...
+@endguest
+
+@guest
+    The user is not authenticated...
+@endguest

--- a/tests/__fixtures__/directive/checked-selected-disabled.blade.php
+++ b/tests/__fixtures__/directive/checked-selected-disabled.blade.php
@@ -1,0 +1,31 @@
+<input type="checkbox"
+        name="active"
+        value="active"
+        @checked(old('active', $user->active)) />
+
+<select name="version">
+    @foreach ($product->versions as $version)
+        <option value="{{ $version }}" @selected(old('version') == $version)>
+            {{ $version }}
+        </option>
+    @endforeach
+</select>
+
+<button type="submit" @disabled($errors->isNotEmpty())>Submit</button>
+----
+<input
+    type="checkbox"
+    name="active"
+    value="active"
+    @checked(old("active", $user->active))
+/>
+
+<select name="version">
+    @foreach ($product->versions as $version)
+        <option value="{{ $version }}" @selected(old("version") == $version)>
+            {{ $version }}
+        </option>
+    @endforeach
+</select>
+
+<button type="submit" @disabled($errors->isNotEmpty())>Submit</button>

--- a/tests/__fixtures__/directive/class.blade.php
+++ b/tests/__fixtures__/directive/class.blade.php
@@ -1,0 +1,13 @@
+<span @class([
+    'p-4',
+    'font-bold' => $isActive,
+    'text-gray-500' => ! $isActive,
+    'bg-red' => $hasError,
+])></span>
+----
+<span @class([
+    "p-4",
+    "font-bold" => $isActive,
+    "text-gray-500" => !$isActive,
+    "bg-red" => $hasError,
+])></span>

--- a/tests/__fixtures__/directive/each.blade.php
+++ b/tests/__fixtures__/directive/each.blade.php
@@ -1,0 +1,7 @@
+@each('view.name', $jobs, 'job')
+
+@each('view.name', $jobs, 'job', 'view.empty')
+----
+@each("view.name", $jobs, "job")
+
+@each("view.name", $jobs, "job", "view.empty")

--- a/tests/__fixtures__/directive/empty-with-else-directive.blade.php
+++ b/tests/__fixtures__/directive/empty-with-else-directive.blade.php
@@ -1,0 +1,9 @@
+@empty($records)
+    // $records is "empty"...@else // $records is FULL...
+                             @endempty
+----
+@empty($records)
+    // $records is "empty"...
+@else
+    // $records is FULL...
+@endempty

--- a/tests/__fixtures__/directive/if-else-directive.blade.php
+++ b/tests/__fixtures__/directive/if-else-directive.blade.php
@@ -5,9 +5,9 @@
     I don't have any records!@endif
 
 ----
-@if(count($records) === 1)
+@if (count($records) === 1)
     I have one record!
-@elseif(count($records) > 1)
+@elseif (count($records) > 1)
     I have multiple records!
 @else
     I don't have any records!

--- a/tests/__fixtures__/directive/include.blade.php
+++ b/tests/__fixtures__/directive/include.blade.php
@@ -1,0 +1,35 @@
+<div>
+    @include('shared.errors')
+
+    <form>
+        <!-- Form Contents -->
+    </form>
+</div>
+
+@include('view.name', ['status' => 'complete'])
+
+@includeIf('view.name', ['status' => 'complete'])
+
+@includeWhen($boolean, 'view.name', ['status' => 'complete'])
+
+@includeUnless($boolean, 'view.name', ['status' => 'complete'])
+
+@includeFirst(['custom.admin', 'admin'], ['status' => 'complete'])
+----
+<div>
+    @include("shared.errors")
+
+    <form>
+        <!-- Form Contents -->
+    </form>
+</div>
+
+@include("view.name", ["status" => "complete"])
+
+@includeIf("view.name", ["status" => "complete"])
+
+@includeWhen($boolean, "view.name", ["status" => "complete"])
+
+@includeUnless($boolean, "view.name", ["status" => "complete"])
+
+@includeFirst(["custom.admin", "admin"], ["status" => "complete"])

--- a/tests/__fixtures__/directive/superfluous-spaces-directive.blade.php
+++ b/tests/__fixtures__/directive/superfluous-spaces-directive.blade.php
@@ -12,11 +12,11 @@ baaad
 </h1>
 ----
 <h1>
-    @if(true)
+    @if (true)
         goood
     @endif
 
-    @if("test" === "test")
+    @if ("test" === "test")
         baaad
     @endif
 </h1>

--- a/tests/__fixtures__/directive/switch.blade.php
+++ b/tests/__fixtures__/directive/switch.blade.php
@@ -1,0 +1,25 @@
+@switch (
+    $i
+)
+    @case(1)
+        First case...
+        @break
+
+    @case(2) Second case... @break
+
+    @default
+    Default case...
+@endswitch
+----
+@switch($i)
+    @case(1)
+        First case...
+        @break
+
+    @case(2)
+        Second case...
+        @break
+
+    @default
+        Default case...
+@endswitch

--- a/tests/__fixtures__/directive/unless-directive.blade.php
+++ b/tests/__fixtures__/directive/unless-directive.blade.php
@@ -2,6 +2,6 @@
 You are not signed in.
 @endunless
 ----
-@unless(Auth::check())
+@unless (Auth::check())
     You are not signed in.
 @endunless

--- a/tests/__fixtures__/echo/deeply-nested-long-lines.blade.php
+++ b/tests/__fixtures__/echo/deeply-nested-long-lines.blade.php
@@ -1,0 +1,28 @@
+<div1>
+    <div2>
+        <div3>
+            <div4>
+                <div5>
+                    {{ $aModel->created_at->tz("America/New_York")->diffForHumans() }}
+                </div5>
+            </div4>
+        </div3>
+    </div2>
+</div1>
+----
+<div1>
+    <div2>
+        <div3>
+            <div4>
+                <div5>
+                    {{
+                        $aModel
+                            ->created_at
+                            ->tz("America/New_York")
+                            ->diffForHumans()
+                    }}
+                </div5>
+            </div4>
+        </div3>
+    </div2>
+</div1>

--- a/tests/__fixtures__/echo/in-html-attributes.blade.php
+++ b/tests/__fixtures__/echo/in-html-attributes.blade.php
@@ -1,0 +1,32 @@
+<x-self-closing-tag
+:model="$model"
+    :visible-data-here="$visibleDataHere"
+{{ $attributes }}
+/>
+
+<div x-data="initModal()"
+    x-init="[
+        modalOnClose(() => { {!! $onClose !!} }),
+        $watch('show', show => onShowOrClose(show))
+    ]"
+  {{ $attributes }}
+>
+  {{ $slot }}
+</div>
+----
+<x-self-closing-tag
+    :model="$model"
+    :visible-data-here="$visibleDataHere"
+    {{ $attributes }}
+/>
+
+<div
+    x-data="initModal()"
+    x-init="[
+        modalOnClose(() => { {!! $onClose !!} }),
+        $watch('show', show => onShowOrClose(show))
+    ]"
+    {{ $attributes }}
+>
+    {{ $slot }}
+</div>

--- a/tests/__fixtures__/echo/multi-line.blade.php
+++ b/tests/__fixtures__/echo/multi-line.blade.php
@@ -1,0 +1,30 @@
+{{ $foo ->bar(  ) }}
+
+{{
+  $abc
+    ->def()
+}}
+
+{{ fizz()->buzz()->fuzz() }}
+
+{{
+  abc()
+  ->def()
+    ->ghi()
+}}
+----
+{{ $foo->bar() }}
+
+{{ $abc->def() }}
+
+{{
+  fizz()
+      ->buzz()
+      ->fuzz()
+}}
+
+{{
+  abc()
+      ->def()
+      ->ghi()
+}}

--- a/tests/__fixtures__/html/javascript.blade.php
+++ b/tests/__fixtures__/html/javascript.blade.php
@@ -1,0 +1,15 @@
+<script>
+    {{-- This is a blade comment. --}}
+    var foo = @js ($bar);
+    var buzz = @js( 'baz'    );
+    var fuzz = '{{ '8' }}'
+    var frizz = {{ 9 }};
+</script>
+----
+<script>
+    {{-- This is a blade comment. --}}
+    var foo = @js($bar);
+    var buzz = @js("baz");
+    var fuzz = "{{ "8" }}";
+    var frizz = {{ 9 }};
+</script>

--- a/tests/__fixtures__/html/vue-alpine-attributes.blade.php
+++ b/tests/__fixtures__/html/vue-alpine-attributes.blade.php
@@ -1,0 +1,13 @@
+<div
+  x-show="show"
+      x-cloak
+  @click="show = false"
+      class="absolute inset-0 bg-black bg-opacity-50"
+></div>
+----
+<div
+    x-show="show"
+    x-cloak
+    @click="show = false"
+    class="absolute inset-0 bg-black bg-opacity-50"
+></div>

--- a/tests/__fixtures__/once.blade.php
+++ b/tests/__fixtures__/once.blade.php
@@ -1,0 +1,27 @@
+@once
+    @push('scripts')
+        <script>
+            // Your custom JavaScript...
+        </script>
+    @endpush
+@endonce
+
+@pushOnce('scripts')
+    <script>
+        // Your custom JavaScript...
+    </script>
+@endPushOnce
+----
+@once
+    @push("scripts")
+        <script>
+            // Your custom JavaScript...
+        </script>
+    @endpush
+@endonce
+
+@pushOnce("scripts")
+    <script>
+        // Your custom JavaScript...
+    </script>
+@endPushOnce


### PR DESCRIPTION
This adds lots more fixture tests, some passing, many failing. (Sorry not sorry! :smile:)

I tried this out on one of my projects and the good news is that it's *working great* in many cases! :tada:

But of course there's still plenty of work to do. This PR includes tests that I lifted from the Laravel docs, as well some examples that I found when formatting my project. These include:

- Confirm that comments are left as is and are not wrapped
- Copied many directives from Laravel docs to confirm that we can/will cover them
  - `@switch`, `@include`, `@checked`, etc, etc
- Changes expectation for `@if`, `@elseif` and `@unless` to have a space between the directive and the paren. This matches PHP and the Laravel docs, as well as our newish support for formatting loops
- echo braces should respect current indent level and wrap @ 80 chars
- echo braces (well all braces, I think) aren't recognized when they span multiple lines
- Echo braces that get formatted onto multiple lines are ugly and need some work
- Echo braces and directives need to support usage within element attributes (eg `<input {{ $attrs }} />`). Currently they only work sometimes, and then just by accident, b/c they get "formatted" as HTML that looks like `<input <e-1-xx /> />`, which isn't right.
- Vue/Alpine event handlers (eg `@click="foo"`) aren't supported



I have fixes ready for Vue/Alpine events and spaces for conditionals. I'll push them sometime soon.

Thanks!