### PR TITLE
More fixes: Vue/Alpine event handlers, spaces in conditionals & shorter placeholders

### DIFF
--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -80,8 +80,15 @@ function matchDirective(text: string, startOffset: number) {
         charCode = text.charAt(possibleEndOffset);
     }
 
-    // Check if next char is an open parenthesis
     charCode = text.charAt(possibleEndOffset);
+
+    // If the next char is `=`, then this might be a Vue or Alpine-style event
+    // binding. Regardless, it's not a directive!
+    if (charCode == "=") {
+        return null;
+    }
+
+    // Check if next char is an open parenthesis
     if (charCode == "(") {
         let parentheses = 1;
         let inSingleComment = false;

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -76,11 +76,17 @@ export class DirectiveNode implements Node {
 
     toString(): string {
         var code = "";
-        var loopSpacer = "";
-
-        if (["for", "foreach", "forelse", "while"].includes(this.directive)) {
-            loopSpacer = " ";
-        }
+        var spacer = [
+            "for",
+            "foreach",
+            "forelse",
+            "while",
+            "if",
+            "elseif",
+            "unless",
+        ].includes(this.directive)
+            ? " "
+            : "";
 
         if (this.directive === "for") {
             code = formatAsPhp(`for (${this.code}) {\n}`).slice(4, -4);
@@ -93,7 +99,7 @@ export class DirectiveNode implements Node {
             code = formatAsPhp(`a(${this.code})`).substring(1);
         }
 
-        return `@${this.directive}${loopSpacer}${code}`;
+        return `@${this.directive}${spacer}${code}`;
     }
 
     toHtml(): HtmlOutput {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,9 +79,12 @@ export const formatAsPhp = (source: string): string => {
 };
 
 let id = 1;
-
 export const nextId = () => {
-    return ++id;
+    // `id` is just a base 10 int, but we format it into a base36 numeric string
+    // which allows us to pack 1295 possible values into just 2 characters.
+    // This helps us keep our placeholders small and makes it less likely to
+    // incorrectly reflow inline elements like echo statements.
+    return (++id).toString(36);
 };
 
 export const placeholderElement = (prefix: string, content: string): string => {

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -197,6 +197,17 @@ it("should generate literal tokens for parenthesis with open parenthesis on next
     expect(tokens).toHaveLength(6);
 });
 
+it("should generate literal tokens for 'fake' directives like Vue and Alpine style event handlers", () => {
+    const input = '@click="foo()"';
+    const tokens = lex(input);
+
+    expect(tokens).toHaveLength(14);
+    tokens.forEach((t, i) => {
+        expect(t).toHaveProperty("tokenType.name", Token.Literal);
+        expect(t).toHaveProperty("image", input.substring(i, i + 1));
+    });
+});
+
 it("should match echo with non php around it", function () {
     const tokens = lex("does it  {{ 'work' }}?").filter(
         (token) => token.tokenType.name !== Token.Literal


### PR DESCRIPTION
1. Updates directive matching so that directives can't ends in `=`. This means we won't try to treat Vue/Alpine event handlers (ie `@click="foo"`) like directives, instead we'll leave them as is.
2. Adds spaces between the directive name and parens for conditional directives (if, elseif and unless). This matches prettier's PHP formatting for if/elseif, plus it matches the Laravel docs.
3. Formats the `id` we use in placeholder elements as a base 36 number instead of base 10.  

This last one is sort of yak shaving or maybe just nitpicking, but I noticed that some tests were failing when all of the fixtures were run vs when just a single fixture was run. The issue was that our idea was incrementing and growing in digits. The tests in question worked when the id was < 100 (ie 2 digits) but failed when it was 3 digits. Switching to base 36 means that we can fit 1295 id's into just 2 chars, reducing the likelihood that we'll incorrectly flow or format certain paragraphs.