### PR TITLE
feat: support for echos in HTML elements using placeholder strings (closes #45)

### DIFF
--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -1,4 +1,9 @@
-import { formatAsPhp, nextId, placeholderElement } from "../../utils";
+import {
+    formatAsPhp,
+    nextId,
+    placeholderString,
+    placeholderElement,
+} from "../../utils";
 
 export type AsHtml = string | HtmlOutput | AsHtml[];
 
@@ -55,7 +60,7 @@ export class EchoNode implements Node {
 
     toHtml(): HtmlOutput {
         return {
-            asHtml: placeholderElement("e", this.toString()),
+            asHtml: placeholderString("e", this.toString()),
             asReplacer: this.toString(),
         };
     }
@@ -218,7 +223,7 @@ export class CommentNode implements Node {
 
     toHtml(): HtmlOutput {
         return {
-            asHtml: placeholderElement("c", this.toString()),
+            asHtml: placeholderString("c", this.toString()),
             asReplacer: this.toString(),
         };
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -84,6 +84,22 @@ export const nextId = () => {
     return ++id;
 };
 
+export const placeholderString = (prefix: string, content: string): string => {
+    let placeholder = `__${prefix}_${nextId()}`;
+
+    // The placeholder is as short as we can make it. If it's already "too long"
+    // then use it as it b/c there's nothing we can do about it.
+    if (placeholder.length >= content.length) {
+        return placeholder;
+    }
+
+    let lengthToPad = content.length - placeholder.length;
+
+    // Pad the placeholder to be as long as the "content" so it can be wrapped
+    // correctly.
+    return `__${prefix}_${nextId()}_${"x".repeat(lengthToPad - 1)}`;
+};
+
 export const placeholderElement = (prefix: string, content: string): string => {
     let placeholder = `<${prefix}-${nextId()} />`;
 

--- a/tests/__fixtures__/echo/multi-line.blade.php
+++ b/tests/__fixtures__/echo/multi-line.blade.php
@@ -1,9 +1,9 @@
-{{ $foo ->bar(  ) }}
+<div>{{ $foo ->bar(  ) }}</div>
 
-{{
-  $abc
-    ->def()
-}}
+<div>{{
+    $abc
+      ->def()
+  }}</div>
 
 {{ fizz()->buzz()->fuzz() }}
 
@@ -13,9 +13,9 @@
     ->ghi()
 }}
 ----
-{{ $foo->bar() }}
+<div>{{ $foo->bar() }}</div>
 
-{{ $abc->def() }}
+<div>{{ $abc->def() }}</div>
 
 {{
   fizz()

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,4 +1,4 @@
-import { placeholderElement } from "../src/utils";
+import { placeholderElement, placeholderString } from "../src/utils";
 
 describe("placeholderElement", () => {
     it("has a minimum length", () => {
@@ -6,14 +6,32 @@ describe("placeholderElement", () => {
         let placeHolder = placeholderElement("foo", content);
 
         expect(content.length).toBeLessThan(placeHolder.length);
-        expect(placeHolder).toMatch(/<foo-\d \/>/);
+        expect(placeHolder).toMatch(/<foo-. \/>/);
     });
 
     it("pads output to match length of content", () => {
         let content = "{{ $thisHasLength22 }}";
         let placeHolder = placeholderElement("foo", content);
 
-        expect(content.length).toBe(placeHolder.length);
-        expect(placeHolder).toMatch(/<foo-\d-x+ \/>/);
+        expect(placeHolder.length).toBe(content.length);
+        expect(placeHolder).toMatch(/<foo-.-x+ \/>/);
+    });
+});
+
+describe("placeholderString", () => {
+    it("has a minimum length", () => {
+        let content = "1";
+        let placeHolder = placeholderString("foo", content);
+
+        expect(content.length).toBeLessThan(placeHolder.length);
+        expect(placeHolder).toMatch(/__foo_./);
+    });
+
+    it("pads output to match length of content", () => {
+        let content = "{{ $thisHasLength22 }}";
+        let placeHolder = placeholderString("foo", content);
+
+        expect(placeHolder.length).toBe(content.length);
+        expect(placeHolder).toMatch(/__foo_._x+/);
     });
 });


### PR DESCRIPTION
This implements the changes to echo placeholders I droned on about in #45. In short, it changes the placeholders used for echo (and comment) statements from `<e-1-xxx />` to `e_1_xxxxxx`. This allows us to support blade echos within elements like `<input {{ $attribute }} />`, which are otherwise sent through the HTML formatter as `<input <e-1-xxx /> />`. This works if those don't get wrapped, but if there is wrapping, our replacement technique starts to fall apart.

So, benefits: it works in all of the cases thrown at it so far.

Downsides: the current implementation relies on things like `<e-1-xxx />` being unique in the document, and this feels like a safe assumption. `e-1` is not an HTML element and it's an odd-enough name for a web component that it feels unlikely to collide w/ code the user is working with. On the other hand, something like `e_1` feels *a lot* more likely to collide w/ the user's code, resulting in us replacing the wrong parts of the document. Now, realistically, the shortest echo statement we could be replacing is `{{ 1 }}` which is 7 chars, so these placeholders would be more like `e_1_xxx`. This feels a lot less likely to collide, but still not collision proof. It might be good enough for now, though, while we're in development.

Alternatives:
- This is honestly my last idea for how to use our current system for replacements while making it work within elements *and* JS. Aside from this, I suppose we could look at a much expanded, more HTML aware parser/lexer that could use different placeholders depending on where the statement is located.
- We could use a random string to generate the padding; this would reduce the likelihood of collisions
- We could perhaps just admit that there are going to be limits to what we can do, draw a line in the sand and call some of these things "known issues".
- I tried using "attribute" style placeholders like `e-1="xxx"` and this worked OK until we tried something like `class="{{ $classes }}"`, which would be sent through the HTML formatter as `class="e-1="xxx""` and the extra `"` broke things. This approached worked OK w/ JS, but also felt frail b/c it's going to turn things like `var foo = {{ $number }}` into `var foo = e-1=""` and the JS parser might complain about that.

Eager to hear thoughts (and other ideas) about this!

