### PR TITLE
fix(plugin): passthrough prettier options into html/php formatters (closes #41)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,9 +6,32 @@ const tw = require("prettier-plugin-tailwindcss");
 const htmlDebug = false;
 const phpDebug = false;
 
-let pluginOptions: ParserOptions;
+let htmlOptions: ParserOptions;
+let phpOptions: ParserOptions;
 export const setOptions = (options: ParserOptions) => {
-    pluginOptions = options;
+    htmlOptions = Object.assign({}, options, {
+        parser: "html",
+        plugins: [{ parsers: { html: tw.parsers.html } }],
+    });
+
+    phpOptions = Object.assign({}, options, { parser: "php", plugins: [php] });
+
+    // FIXME there *must* be a better way to get just the user configurable options?!
+    [
+        "cursorOffset",
+        "rangeEnd",
+        "rangeStart",
+        "locEnd",
+        "locStat",
+        "printer",
+        "originalText",
+        "astFormat",
+    ].forEach((p) => {
+        // @ts-ignore
+        delete htmlOptions[p];
+        // @ts-ignore
+        delete phpOptions[p];
+    });
 };
 
 export const formatAsHtml = (source: string): string => {
@@ -18,11 +41,7 @@ export const formatAsHtml = (source: string): string => {
     htmlDebug && debugOutput.push(`source:    '${source}'`);
 
     try {
-        formatted = format(source, {
-            parser: "html",
-            plugins: [{ parsers: { html: tw.parsers.html } }],
-            tabWidth: pluginOptions?.tabWidth,
-        });
+        formatted = format(source, htmlOptions);
     } catch (e) {
         htmlDebug && debugOutput.push("error: defaulting to source");
 
@@ -56,7 +75,7 @@ export const formatAsPhp = (source: string): string => {
     phpDebug && debugOutput.push(`manipulated: '${manipulated}'`);
 
     try {
-        formatted = format(manipulated, { parser: "php", plugins: [php] })
+        formatted = format(manipulated, phpOptions)
             .replace("<?php ", "")
             .trim();
     } catch (e) {


### PR DESCRIPTION
I'm parking this here for discussion b/c I need to play w/ it some more before I'm comfortable w/ it. In short, this tries to pass all user-configurable options from the main `prettier` instance into each of the formatters we use. As is, I'm fairly certain we're ignoring user configured settings when calling the the html/php formatters. See #41, but you can also demonstrate this on the command line like so:

```
❯ npm run build

❯ cat foo.blade.php
<body>
  {{ 'hello' }}
  <script>
    var foo = 'abc';
  </script>
</body>

❯ ./node_modules/.bin/prettier --parser blade --plugin . foo.blade.php
<body>
    {{ "hello" }}
    <script>
        var foo = "abc";
    </script>
</body>

# OK, so far, so good, now lets specify some config options:
❯ ./node_modules/.bin/prettier --parser blade --plugin . foo.blade.php --single-quote
<body>
    {{ "hello" }}
    <script>
        var foo = "abc";
    </script>
</body>

# uh oh, where's our single quotes? let's try this branch...
❯ git co passthrough-options
❯ npm run build

# first w/o options:
❯ ./node_modules/.bin/prettier --parser blade --plugin . foo.blade.php
<body>
    {{ "hello" }}
    <script>
        var foo = "abc";
    </script>
</body>

# Ok, that's the same as above. And now with an option:
❯ ./node_modules/.bin/prettier --parser blade --plugin . foo.blade.php --single-quote
<body>
    {{ 'hello' }}
    <script>
        var foo = 'abc';
    </script>
</body>

# tada!
```

So, I think that this is getting closer to what we want, but I *hate* how I did it. I just don't know enough about prettier to know if there is a more idiomatic way to get just the user-configurable options, or if there is some other way to handle the global options that are passed around. As I understand, the global options include some add'l state that is used for keeping track of where the formatter is in the document, but *I tried* to pass these through directly to each plugin and that was causing incorrect formatting. So the method in use here is to make a copy of the options and then customize each as needed before deleting the properties we don't want/need.

A couple more items:
1. I think that `Object.assign()` is a shallow copy, so the array and objects copied from the main options might be getting copied by reference vs being cloned. This hasn't been an issue in practice, but I can see how it could.

2. I also removed the default option of 4 space tabwidth. Was the though on that to force all Blade files to 4 spaces regardless of user's preference (the php plugin does this for php code, fwiw), or was that aimed for something else? Personally, if the user likes 2 space tabs for their HTML, I'm inclined to let them have it. Note that b/c PHP is hardcoded to 4 spaces, that won't affect that code at all.

Would love some input on this, if you have any. Thank you!