### PR TITLE
`@unless`, `@empty` and `@forelse`

### DIFF
--- a/src/lang/blade_cst.d.ts
+++ b/src/lang/blade_cst.d.ts
@@ -19,6 +19,7 @@ export type ContentCstChildren = {
     pairDirective?: PairDirectiveCstNode[];
     directive?: DirectiveCstNode[];
     ifDirectiveBlock?: IfDirectiveBlockCstNode[];
+    forElseDirectiveBlock?: ForElseDirectiveBlockCstNode[];
     echo?: EchoCstNode[];
     rawEcho?: RawEchoCstNode[];
     comment?: CommentCstNode[];
@@ -125,8 +126,17 @@ export interface StartIfDirectiveCstNode extends CstNode {
     children: StartIfDirectiveCstChildren;
 }
 
+export interface StartForElseDirectiveCstNode extends CstNode {
+    name: "startForElseDirective";
+    children: StartForElseDirectiveCstChildren;
+}
+
 export type StartIfDirectiveCstChildren = {
     StartIfDirective: IToken[];
+};
+
+export type StartForElseDirectiveCstChildren = {
+    StartForElseDirective: IToken[];
 };
 
 export interface EndIfDirectiveCstNode extends CstNode {
@@ -134,8 +144,17 @@ export interface EndIfDirectiveCstNode extends CstNode {
     children: EndIfDirectiveCstChildren;
 }
 
+export interface EndForElseDirectiveCstNode extends CstNode {
+    name: "endForElseDirective";
+    children: EndForElseDirectiveCstChildren;
+}
+
 export type EndIfDirectiveCstChildren = {
     EndIfDirective: IToken[];
+};
+
+export type EndForElseDirectiveCstChildren = {
+    EndForElseDirective: IToken[];
 };
 
 export interface ElseDirectiveCstNode extends CstNode {
@@ -143,8 +162,17 @@ export interface ElseDirectiveCstNode extends CstNode {
     children: ElseDirectiveCstChildren;
 }
 
+export interface EmptyDirectiveCstNode extends CstNode {
+    name: "emptyDirective";
+    children: EmptyDirectiveCstChildren;
+}
+
 export type ElseDirectiveCstChildren = {
     ElseDirective: IToken[];
+};
+
+export type EmptyDirectiveCstChildren = {
+    EmptyDirective: IToken[];
 };
 
 export interface ElseIfDirectiveCstNode extends CstNode {
@@ -161,8 +189,18 @@ export interface ElseBlockCstNode extends CstNode {
     children: ElseBlockCstChildren;
 }
 
+export interface EmptyBlockCstNode extends CstNode {
+    name: "emptyBlock";
+    children: EmptyBlockCstChildren;
+}
+
 export type ElseBlockCstChildren = {
     elseDirective: ElseDirectiveCstNode[];
+    content?: ContentCstNode[];
+};
+
+export type EmptyBlockCstChildren = {
+    emptyDirective: EmptyDirectiveCstNode[];
     content?: ContentCstNode[];
 };
 
@@ -181,12 +219,24 @@ export interface IfDirectiveBlockCstNode extends CstNode {
     children: IfDirectiveBlockCstChildren;
 }
 
+export interface ForElseDirectiveBlockCstNode extends CstNode {
+    name: "forElseDirectiveBlock";
+    children: ForElseDirectiveBlockCstChildren;
+}
+
 export type IfDirectiveBlockCstChildren = {
     startDirective: StartIfDirectiveCstNode[];
     content?: ContentCstNode[];
     elseIfBlock?: ElseIfBlockCstNode[];
     elseBlock?: ElseBlockCstNode[];
     endDirective: EndIfDirectiveCstNode[];
+};
+
+export type ForElseDirectiveBlockCstChildren = {
+    startDirective: StartForElseDirectiveCstNode[];
+    content?: ContentCstNode[];
+    emptyBlock?: EmptyBlockCstNode[];
+    endDirective: EndForElseDirectiveCstNode[];
 };
 
 export interface StartVerbatimDirectiveCstNode extends CstNode {

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -15,6 +15,9 @@ export enum Token {
     ElseIfDirective = "ElseIfDirective",
     ElseDirective = "ElseDirective",
     EndIfDirective = "EndIfDirective",
+    StartForElseDirective = "StartForElseDirective",
+    EmptyDirective = "EmptyDirective",
+    EndForElseDirective = "EndForElseDirective",
     StartVerbatimDirective = "StartVerbatimDirective",
     EndVerbatimDirective = "EndVerbatimDirective",
     StartPhpDirective = "StartPhpDirective",
@@ -34,7 +37,6 @@ export const terminalDirectives = [
     "error",
     "for",
     "foreach",
-    "forelse",
     "guest",
     "isset",
     "once",
@@ -347,6 +349,84 @@ export const EndIfDirectiveWithArgs = createToken({
     line_breaks: false,
 });
 
+export const StartForElseDirectiveWithArgs = createToken({
+    name: Token.StartForElseDirective,
+    pattern: {
+        exec(
+            text: string,
+            startOffset: number
+        ): CustomPatternMatcherReturn | null {
+            const result = matchDirective(text, startOffset);
+
+            if (result === null) {
+                return null;
+            }
+
+            // Check if `@forelse` directive
+            if (result.directiveName !== "forelse") {
+                return null;
+            }
+
+            return [result.matches];
+        },
+    },
+    start_chars_hint: ["@"],
+    line_breaks: false,
+});
+
+export const EmptyDirectiveWithoutArgs = createToken({
+    name: Token.EmptyDirective,
+    pattern: {
+        exec(
+            text: string,
+            startOffset: number
+        ): CustomPatternMatcherReturn | null {
+            const result = matchDirective(text, startOffset);
+
+            if (result === null) {
+                return null;
+            }
+
+            // Check if `@empty` directive
+            if (
+                result.directiveName !== "empty" ||
+                result.matches.includes("(")
+            ) {
+                return null;
+            }
+
+            return [result.matches];
+        },
+    },
+    start_chars_hint: ["@"],
+    line_breaks: false,
+});
+
+export const EndForElseDirectiveWithArgs = createToken({
+    name: Token.EndForElseDirective,
+    pattern: {
+        exec(
+            text: string,
+            startOffset: number
+        ): CustomPatternMatcherReturn | null {
+            const result = matchDirective(text, startOffset);
+
+            if (result === null) {
+                return null;
+            }
+
+            // Check if `@endforelse` directive
+            if (result.directiveName !== "endforelse") {
+                return null;
+            }
+
+            return [result.matches];
+        },
+    },
+    start_chars_hint: ["@"],
+    line_breaks: false,
+});
+
 export const StartVerbatimDirectiveWithArgs = createToken({
     name: Token.StartVerbatimDirective,
     pattern: {
@@ -466,6 +546,9 @@ export const allTokens = {
             ElseIfDirectiveWithArgs,
             ElseDirectiveWithArgs,
             EndIfDirectiveWithArgs,
+            StartForElseDirectiveWithArgs,
+            EmptyDirectiveWithoutArgs,
+            EndForElseDirectiveWithArgs,
             EndDirectiveWithArgs,
             StartDirectiveWithArgs,
             DirectiveWithArgs,

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -33,7 +33,6 @@ export const terminalDirectives = [
     "auth",
     "can",
     "component",
-    "empty",
     "error",
     "for",
     "foreach",
@@ -43,7 +42,6 @@ export const terminalDirectives = [
     "prepend",
     "push",
     "pushOnce",
-    "unless",
     "while",
 ];
 
@@ -262,12 +260,18 @@ export const StartIfDirectiveWithArgs = createToken({
                 return null;
             }
 
-            // Check if `@if` directive
-            if (result.directiveName !== "if") {
-                return null;
+            // Check if `@if`, `@unless` or `@empty` (w/ args) directive
+            if (
+                result.directiveName === "if" ||
+                result.directiveName === "unless" ||
+                (result.directiveName === "empty" &&
+                    result.matches.includes("("))
+            ) {
+                return [result.matches];
             }
 
-            return [result.matches];
+            // no match
+            return null;
         },
     },
     start_chars_hint: ["@"],
@@ -337,12 +341,17 @@ export const EndIfDirectiveWithArgs = createToken({
                 return null;
             }
 
-            // Check if `@if` directive
-            if (result.directiveName !== "endif") {
-                return null;
+            // Check if `@endif`, `@endunless`, `@endempty` directive
+            if (
+                result.directiveName === "endif" ||
+                result.directiveName === "endunless" ||
+                result.directiveName === "endempty"
+            ) {
+                return [result.matches];
             }
 
-            return [result.matches];
+            // no match
+            return null;
         },
     },
     start_chars_hint: ["@"],
@@ -387,15 +396,15 @@ export const EmptyDirectiveWithoutArgs = createToken({
                 return null;
             }
 
-            // Check if `@empty` directive
+            // Check if `@empty` directive w/o args
             if (
-                result.directiveName !== "empty" ||
-                result.matches.includes("(")
+                result.directiveName === "empty" &&
+                !result.matches.includes("(")
             ) {
-                return null;
+                return [result.matches];
             }
 
-            return [result.matches];
+            return null;
         },
     },
     start_chars_hint: ["@"],

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -275,6 +275,44 @@ export class DirectiveIfBlockNode implements Node {
     }
 }
 
+export class DirectiveForElseBlockNode implements Node {
+    constructor(
+        public open: DirectiveNode,
+        public close: DirectiveNode,
+        public children: Node[],
+        public emptyBlock: DirectiveEmptyBlockNode | null
+    ) {}
+
+    toHtml(): HtmlOutput {
+        const id = nextId();
+
+        return {
+            asHtml: [
+                `<forelse-open-${id}>`,
+                forceHtmlSplit,
+                ...this.children.map((child) => child.toHtml()),
+                ` </forelse-open-${id}> `,
+                this.emptyBlock?.toHtml() ?? [],
+                ` <forelse-close-${id} />`,
+            ],
+            asReplacer: [
+                {
+                    search: `<forelse-open-${id}>`,
+                    replace: this.open.toString(),
+                },
+                {
+                    search: new RegExp(`\n?.*<\\/forelse-open-${id}>`),
+                    replace: "",
+                },
+                {
+                    search: new RegExp(`<forelse-close-${id} \\/>`),
+                    replace: this.close.toString(),
+                },
+            ],
+        };
+    }
+}
+
 export class DirectiveElseBlockNode implements Node {
     constructor(public elseDirective: DirectiveNode, public children: Node[]) {}
 
@@ -295,6 +333,36 @@ export class DirectiveElseBlockNode implements Node {
                 },
                 {
                     search: new RegExp(`\n?.*<\\/else-${id}>`),
+                    replace: "",
+                },
+            ],
+        };
+    }
+}
+
+export class DirectiveEmptyBlockNode implements Node {
+    constructor(
+        public emptyDirective: DirectiveNode,
+        public children: Node[]
+    ) {}
+
+    toHtml(): HtmlOutput {
+        const id = nextId();
+
+        return {
+            asHtml: [
+                ` <empty-${id}>`,
+                forceHtmlSplit,
+                ...this.children.map((child) => child.toHtml()),
+                ` </empty-${id}>`,
+            ],
+            asReplacer: [
+                {
+                    search: `<empty-${id}>`,
+                    replace: this.emptyDirective.toString(),
+                },
+                {
+                    search: new RegExp(`\n?.*<\\/empty-${id}>`),
                     replace: "",
                 },
             ],

--- a/src/lang/parser.ts
+++ b/src/lang/parser.ts
@@ -6,9 +6,11 @@ import {
     DirectiveWithArgs,
     Echo,
     ElseDirectiveWithArgs,
+    EmptyDirectiveWithoutArgs,
     ElseIfDirectiveWithArgs,
     EndDirectiveWithArgs,
     EndIfDirectiveWithArgs,
+    EndForElseDirectiveWithArgs,
     EndVerbatimDirectiveWithArgs,
     EscapedEcho,
     EscapedRawEcho,
@@ -16,6 +18,7 @@ import {
     RawEcho,
     StartDirectiveWithArgs,
     StartIfDirectiveWithArgs,
+    StartForElseDirectiveWithArgs,
     StartVerbatimDirectiveWithArgs,
     StartPhpDirective,
     EndPhpDirective,
@@ -46,6 +49,9 @@ class BladeToCSTParser extends CstParser {
             },
             {
                 ALT: () => this.SUBRULE(this.ifDirectiveBlock),
+            },
+            {
+                ALT: () => this.SUBRULE(this.forElseDirectiveBlock),
             },
             {
                 ALT: () => this.SUBRULE(this.echo),
@@ -174,6 +180,43 @@ class BladeToCSTParser extends CstParser {
         });
 
         this.SUBRULE(this.endIfDirective, { LABEL: "endDirective" });
+    });
+
+    private startForElseDirective = this.RULE("startForElseDirective", () => {
+        this.CONSUME(StartForElseDirectiveWithArgs);
+    });
+
+    private emptyDirective = this.RULE("emptyDirective", () => {
+        this.CONSUME(EmptyDirectiveWithoutArgs);
+    });
+
+    private endForElseDirective = this.RULE("endForElseDirective", () => {
+        this.CONSUME(EndForElseDirectiveWithArgs);
+    });
+
+    private forElseDirectiveBlock = this.RULE("forElseDirectiveBlock", () => {
+        this.SUBRULE(this.startForElseDirective, { LABEL: "startDirective" });
+        this.OPTION(() => {
+            this.MANY(() => {
+                this.SUBRULE(this.content);
+            });
+        });
+
+        // Empty block
+        this.OPTION2(() => {
+            this.SUBRULE(this.emptyBlock);
+        });
+
+        this.SUBRULE(this.endForElseDirective, { LABEL: "endDirective" });
+    });
+
+    private emptyBlock = this.RULE("emptyBlock", () => {
+        this.SUBRULE(this.emptyDirective, { LABEL: "emptyDirective" });
+        this.OPTION(() => {
+            this.MANY(() => {
+                this.SUBRULE(this.content);
+            });
+        });
     });
 
     private startVerbatimDirective = this.RULE("startVerbatimDirective", () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,7 +2,7 @@ import { AstPath, Doc, Plugin } from "prettier";
 import { AsHtml, AsReplacer, HtmlOutput, Node, Replacer } from "./lang/nodes";
 import { formatAsHtml, setOptions } from "./utils";
 import { bladeToAstVisitor } from "./lang/ASTParser";
-import { parseBlade } from "./lang/Parser";
+import { parseBlade } from "./lang/parser";
 
 const traverseHtml = (original: AsHtml, replacers: Replacer[]): string => {
     if (typeof original === "string") {

--- a/tests/__fixtures__/directive/loops-forelse.blade.php
+++ b/tests/__fixtures__/directive/loops-forelse.blade.php
@@ -6,7 +6,6 @@
     <li>{{
 $user->name
 }}</li>
-{{-- FIXME this test fails b/c @empty is only recognized as @empty(...) ... @endempty --}}
 @empty
 <p>No users</p>
 @endforelse

--- a/tests/__fixtures__/directive/unless-directive.blade.php
+++ b/tests/__fixtures__/directive/unless-directive.blade.php
@@ -1,7 +1,11 @@
 @unless (Auth::check())
 You are not signed in.
+@else
+Welcome back!
 @endunless
 ----
 @unless (Auth::check())
     You are not signed in.
+@else
+    Welcome back!
 @endunless

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -366,3 +366,41 @@ describe("php directives", () => {
         expect(tokens).toHaveLength(1);
     });
 });
+
+describe("loops", () => {
+    it("should parse forelse directive", function () {
+        const tokens = lex("@forelse(true)");
+
+        expect(tokens[0]).toHaveProperty(
+            "tokenType.name",
+            Token.StartForElseDirective
+        );
+        expect(tokens[0]).toHaveProperty("image", "@forelse(true)");
+
+        expect(tokens).toHaveLength(1);
+    });
+
+    it("should parse empty directive", function () {
+        const tokens = lex("@empty");
+
+        expect(tokens[0]).toHaveProperty(
+            "tokenType.name",
+            Token.EmptyDirective
+        );
+        expect(tokens[0]).toHaveProperty("image", "@empty");
+
+        expect(tokens).toHaveLength(1);
+    });
+
+    it("should parse endforelse directive", function () {
+        const tokens = lex("@endforelse");
+
+        expect(tokens[0]).toHaveProperty(
+            "tokenType.name",
+            Token.EndForElseDirective
+        );
+        expect(tokens[0]).toHaveProperty("image", "@endforelse");
+
+        expect(tokens).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
`@unless`, `@empty` and `@forelse` all have only have partial support on `main`. The former 2 are special cases of `@if`, but they break if you try to use `@else` (or `@elseif`) w/i them. The latter breaks if you try to use `@empty` w/i it. This PR adds full support for all three, so that the following snippets now work as expected:

```
@forelse ($users as $user)
    <li>{{ $user->name }}</li>
@empty
    <p>No users</p>
@endforelse

@unless (Auth::check())
    You are not signed in.
@else
    Welcome back.
@endunless

@empty($records)
    // $records is "empty"...
@else
    // $records is FULL...
@endempty
```

**Note regarding `unless` and `empty`**
These are both implemented by piggybacking off of `@if`. This was by far the simplest way forward, but means that the AST will not enforce matching opening/closing directives. For example, `@empty ($test) foo @endunless` and `@if($test) foo @endempty` will both be considered "valid". (Though it's a little sloppy, I think that this is correct since the Blade compiler doesn't care what end tag is used: `endunless`, `endif` and `endempty` are all compiled into `<?php endif; ?>`.) 

When the AST is turned back into text, the mismatched opening/closing tags will be left as is, though I suspect that it would be pretty easy to correct the mismatch at that time, if desired. (ie to make the closing directives match the opening directives.) I haven't tried it, but it might be a nice touch. Thoughts?