### PR TITLE
Another round of misc fixes

### DIFF
--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -30,14 +30,11 @@ enum Mode {
 }
 
 export const terminalDirectives = [
-    "auth",
     "can",
     "component",
     "error",
     "for",
     "foreach",
-    "guest",
-    "isset",
     "once",
     "prepend",
     "push",
@@ -261,10 +258,18 @@ export const StartIfDirectiveWithArgs = createToken({
                 return null;
             }
 
-            // Check if `@if`, `@unless` or `@empty` (w/ args) directive
             if (
-                result.directiveName === "if" ||
-                result.directiveName === "unless" ||
+                [
+                    "if",
+                    "unless",
+                    "auth",
+                    "guest",
+                    "env",
+                    "production",
+                    "hasSection",
+                    "sectionMissing",
+                    "isset",
+                ].includes(result.directiveName) ||
                 (result.directiveName === "empty" &&
                     result.matches.includes("("))
             ) {
@@ -292,12 +297,15 @@ export const ElseIfDirectiveWithArgs = createToken({
                 return null;
             }
 
-            // Check if `@if` directive
-            if (result.directiveName !== "elseif") {
-                return null;
+            if (
+                ["elseif", "elseauth", "elseguest"].includes(
+                    result.directiveName
+                )
+            ) {
+                return [result.matches];
             }
 
-            return [result.matches];
+            return null;
         },
     },
     start_chars_hint: ["@"],
@@ -317,7 +325,7 @@ export const ElseDirectiveWithArgs = createToken({
                 return null;
             }
 
-            // Check if `@if` directive
+            // Check if `@else` directive
             if (result.directiveName !== "else") {
                 return null;
             }
@@ -342,11 +350,17 @@ export const EndIfDirectiveWithArgs = createToken({
                 return null;
             }
 
-            // Check if `@endif`, `@endunless`, `@endempty` directive
             if (
-                result.directiveName === "endif" ||
-                result.directiveName === "endunless" ||
-                result.directiveName === "endempty"
+                [
+                    "endif",
+                    "endunless",
+                    "endauth",
+                    "endguest",
+                    "endenv",
+                    "endproduction",
+                    "endisset",
+                    "endempty",
+                ].includes(result.directiveName)
             ) {
                 return [result.matches];
             }

--- a/src/lang/lexer.ts
+++ b/src/lang/lexer.ts
@@ -62,29 +62,30 @@ function matchDirective(text: string, startOffset: number) {
         return null;
     }
 
-    endOffset++;
-    charCode = text.charAt(endOffset);
+    charCode = text.charAt(++endOffset);
     let directiveName = "";
     // Consume name of directive
     while (/\w/.exec(charCode)) {
-        endOffset++;
         directiveName += charCode;
-        charCode = text.charAt(endOffset);
+        charCode = text.charAt(++endOffset);
     }
 
     // Consume spaces
     let possibleEndOffset = endOffset;
     charCode = text.charAt(possibleEndOffset);
-    while ([" "].includes(charCode)) {
-        possibleEndOffset++;
-        charCode = text.charAt(possibleEndOffset);
+    while (charCode == " ") {
+        charCode = text.charAt(++possibleEndOffset);
     }
 
     charCode = text.charAt(possibleEndOffset);
 
-    // If the next char is `=`, then this might be a Vue or Alpine-style event
-    // binding. Regardless, it's not a directive!
-    if (charCode == "=") {
+    // If a directive appears to end w/ any of these chars, then it may not be a
+    // directive and is probably a Vue/Alpine event binding.
+    if (["=", ".", ":"].includes(charCode)) {
+        // FIXME it's *possible* that the input could be something like
+        // `@auth = @else != @endauth`, and `@event = "method"` is valid HTML,
+        // so perhaps we should look even further a head to confirm that the
+        // *next* char is not a `"` or `'`. ??
         return null;
     }
 

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -278,7 +278,7 @@ export class DirectiveIfBlockNode implements Node {
                     replace: this.open.toString(),
                 },
                 {
-                    search: new RegExp(`\n?.*<\\/if-open-${uuid}>`),
+                    search: new RegExp(`\n?\\s*<\\/if-open-${uuid}>`),
                     replace: "",
                 },
                 {
@@ -316,7 +316,7 @@ export class DirectiveForElseBlockNode implements Node {
                     replace: this.open.toString(),
                 },
                 {
-                    search: new RegExp(`\n?.*<\\/forelse-open-${id}>`),
+                    search: new RegExp(`\n?\\s*<\\/forelse-open-${id}>`),
                     replace: "",
                 },
                 {
@@ -347,7 +347,7 @@ export class DirectiveElseBlockNode implements Node {
                     replace: this.elseDirective.toString(),
                 },
                 {
-                    search: new RegExp(`\n?.*<\\/else-${id}>`),
+                    search: new RegExp(`\n?\\s*<\\/else-${id}>`),
                     replace: "",
                 },
             ],
@@ -377,7 +377,7 @@ export class DirectiveEmptyBlockNode implements Node {
                     replace: this.emptyDirective.toString(),
                 },
                 {
-                    search: new RegExp(`\n?.*<\\/empty-${id}>`),
+                    search: new RegExp(`\n?\\s*<\\/empty-${id}>`),
                     replace: "",
                 },
             ],
@@ -407,7 +407,7 @@ export class DirectiveElseIfBlockNode implements Node {
                     replace: this.elseIfDirective.toString(),
                 },
                 {
-                    search: new RegExp(`\n?.*<\\/else-if-${id}>`),
+                    search: new RegExp(`\n?\\s*<\\/else-if-${id}>`),
                     replace: "",
                 },
             ],

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -392,7 +392,7 @@ export class DirectiveElseIfBlockNode implements Node {
                     replace: this.elseIfDirective.toString(),
                 },
                 {
-                    search: `\n</else-if-${id}>`,
+                    search: new RegExp(`\n?.*<\\/else-if-${id}>`),
                     replace: "",
                 },
             ],

--- a/src/lang/nodes/index.ts
+++ b/src/lang/nodes/index.ts
@@ -108,10 +108,25 @@ export class DirectiveNode implements Node {
     }
 
     toHtml(): HtmlOutput {
-        return {
-            asHtml: `<directive-${this.directive}-${nextId()} />`,
-            asReplacer: this.toString(),
-        };
+        let id = nextId();
+        let asHtml = `<directive-${this.directive}-${id} />`;
+        let asReplacer = this.toString();
+
+        // checked/selected/disabled are "attribute" directives, so we have use
+        // a placeholder string instead of a placeholder element
+        // FIXME this is bare-minimum support
+        if (
+            ["checked", "selected", "disabled"].includes(
+                this.directive.toLowerCase()
+            )
+        ) {
+            asHtml = placeholderString(
+                `directive_${this.directive}`,
+                asReplacer
+            );
+        }
+
+        return { asHtml, asReplacer };
     }
 }
 

--- a/tests/__fixtures__/directive/basics-no-content-single-line.blade.php
+++ b/tests/__fixtures__/directive/basics-no-content-single-line.blade.php
@@ -1,7 +1,11 @@
 @auth ('admin') @endauth
 
+@if ('test') @endif
+
 @customif ('value') @endcustomif
 ----
 @auth("admin") @endauth
+
+@if ("test") @endif
 
 @customif("value") @endcustomif

--- a/tests/__fixtures__/directive/basics-no-content.blade.php
+++ b/tests/__fixtures__/directive/basics-no-content.blade.php
@@ -2,10 +2,16 @@
 
 @endauth
 
+@if ($test)
+
+    @endif
+
 @customif ('value')
 
 @endcustomif
 ----
 @auth("admin") @endauth
+
+@if ($test) @endif
 
 @customif("value") @endcustomif

--- a/tests/__fixtures__/directive/basics-with-content-on-single-line.blade.php
+++ b/tests/__fixtures__/directive/basics-with-content-on-single-line.blade.php
@@ -1,10 +1,16 @@
 @auth ('admin') Hello! @endauth
 
+@if ($test) How are you? @endif
+
 @customif ('value') Goodbye! @endcustomif
 ----
 @auth("admin")
     Hello!
 @endauth
+
+@if ($test)
+    How are you?
+@endif
 
 @customif("value")
     Goodbye!

--- a/tests/__fixtures__/directive/conditionals-nested.blade.php
+++ b/tests/__fixtures__/directive/conditionals-nested.blade.php
@@ -1,0 +1,24 @@
+@unless (is_null($planting))
+@empty ($planting->crop)
+      Create custom crop.
+@elseif ($planting->crop->isCustom())
+  <x-dropdown-button
+
+    />
+
+@else
+  <x-dropdown-button
+
+    />
+@endempty
+@endunless
+----
+@unless (is_null($planting))
+    @empty($planting->crop)
+        Create custom crop.
+    @elseif ($planting->crop->isCustom())
+        <x-dropdown-button />
+    @else
+        <x-dropdown-button />
+    @endempty
+@endunless

--- a/tests/__fixtures__/html/vue-alpine-attributes.blade.php
+++ b/tests/__fixtures__/html/vue-alpine-attributes.blade.php
@@ -2,6 +2,7 @@
   x-show="show"
       x-cloak
   @click="show = false"
+  @blur.stop="show = true"
       class="absolute inset-0 bg-black bg-opacity-50"
 ></div>
 ----
@@ -9,5 +10,6 @@
     x-show="show"
     x-cloak
     @click="show = false"
+    @blur.stop="show = true"
     class="absolute inset-0 bg-black bg-opacity-50"
 ></div>


### PR DESCRIPTION
Added:
- support for all "first party" conditionals defined in [`CompilesConditionals.php`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php) (but still not `@switch`)
- semi-support for `@checked`/`@selected`/`@disabled` (see below)

Fixed:
- formatting an `@elseif` that was indented was leaving behind an `</else-if-${id}>`
- Vue/Alpine event bindings can include periods, eg `@click.stop="foo"`
- Destructive formatting of empty conditionals (#44)

Notes:
- `@checked` et al are special b/c they really only make sense w/i an element, but they were being formatted as if they were elements, which led to invalid markup and formatting errors. This is the same issue as #45. As noted, this is an MVP fix for that: basically if we have a `DirectiveNode` that matches checked/selected/disabled, we use a string placeholder instead of an element placeholder. The thinking here is that these will most often be used w/i elements. There is the chance that someone has defined their own `@disabled` etc directive; if so, this will lead to funky formatting for that poor soul. 
- For the Vue/Alpine fix, this was easy enough, but I wonder if there are other characters we should be on the lookout for.
- #44 is closed by changing the regexps to only match whitespace (`\s*`) instead of anything (`.*`).

These have been working *splendidly* for me locally. I'll park this here for a while for folks to peek at/comment if they'd like.
